### PR TITLE
Add Docker Compose stack and CI/CD workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Variables de entorno compartidas por los servicios
+POSTGRES_DB=app_db
+POSTGRES_USER=app_user
+POSTGRES_PASSWORD=super-secret-password
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+
+# Configuración del backend
+NOTIFICATION_MORNING_WINDOW=08:00-09:00
+NOTIFICATION_EVENING_WINDOW=18:00-19:00
+NOTIFICATION_TIMEZONE=Europe/Madrid

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,65 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  pull_request:
+
+jobs:
+  build-and-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configurar entorno
+        run: cp .env.example .env
+
+      - name: Construir servicios
+        run: docker compose build
+
+      - name: Validar horario de notificaciones
+        run: |
+          source .env
+          python - <<'PY'
+import os
+
+for key in ("NOTIFICATION_MORNING_WINDOW", "NOTIFICATION_EVENING_WINDOW"):
+    value = os.environ.get(key)
+    if value is None:
+        raise SystemExit(f"Variable {key} no está definida")
+    if "-" not in value:
+        raise SystemExit(f"Formato inválido para {key}: {value}")
+print("Variables de horario válidas")
+PY
+
+      - name: Ejecutar pruebas del backend
+        working-directory: backend
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m compileall app
+
+      - name: Publicar artefacto del docker-compose
+        uses: actions/upload-artifact@v4
+        with:
+          name: docker-compose
+          path: docker-compose.yml
+
+  deploy:
+    needs: build-and-verify
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Preparar entorno
+        run: cp .env.example .env
+
+      - name: Despliegue automatizado
+        run: |
+          chmod +x scripts/deploy.sh
+          ./scripts/deploy.sh

--- a/Desarrollo web/Dockerfile
+++ b/Desarrollo web/Dockerfile
@@ -1,0 +1,3 @@
+FROM nginx:1.25-alpine
+
+COPY . /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -1,1 +1,75 @@
-Bienvenido/a a este repositorio. Aquí encontrarás una colección de proyectos y ejercicios que he desarrollado a lo largo de mi carrera. Esta carpeta sirve como un espacio de práctica, aprendizaje y crecimiento, donde exploro distintas tecnologías, lenguajes de programación y conceptos clave.
+# Computing
+
+Este repositorio reúne distintos proyectos y ejercicios desarrollados para practicar tecnologías web, análisis de datos y machine learning. Además se incluyen los recursos necesarios para ejecutar una pila de ejemplo formada por un frontend estático, un backend en FastAPI y una base de datos PostgreSQL.
+
+## 📦 Instalación
+
+1. **Requisitos previos**
+   - Docker y Docker Compose Plugin (`docker compose`).
+   - Bash (para ejecutar los scripts de automatización).
+
+2. **Clonar el repositorio**
+   ```bash
+   git clone <url-del-repositorio>
+   cd Computing
+   ```
+
+3. **Configurar variables de entorno**
+   - Copia el archivo `.env.example` y renómbralo a `.env`.
+   - Ajusta las credenciales de base de datos y las ventanas horarias de notificaciones según tus necesidades.
+   ```bash
+   cp .env.example .env
+   ```
+
+## ▶️ Uso
+
+Con los requisitos previos instalados y el archivo `.env` configurado puedes levantar los servicios con Docker Compose:
+
+```bash
+docker compose up --build
+```
+
+Los servicios expuestos son:
+
+| Servicio   | Puerto local | Descripción |
+|------------|--------------|-------------|
+| Frontend   | `http://localhost:8080` | Sitio estático contenido en `Desarrollo web/` servido con Nginx. |
+| Backend    | `http://localhost:8000` | API FastAPI con endpoints de salud y consulta de horarios de notificación. |
+| Base de datos | `localhost:5432` | Instancia PostgreSQL con volúmenes persistentes. |
+
+Para detener los servicios ejecuta:
+
+```bash
+docker compose down
+```
+
+### Variables de entorno relevantes
+
+| Variable | Descripción |
+|----------|-------------|
+| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT` | Configuración de la base de datos PostgreSQL. |
+| `NOTIFICATION_MORNING_WINDOW`, `NOTIFICATION_EVENING_WINDOW` | Ventanas horarias (formato `HH:MM-HH:MM`) utilizadas por el backend para programar notificaciones. |
+| `NOTIFICATION_TIMEZONE` | Zona horaria que se empleará al interpretar las ventanas configuradas. |
+
+El backend expone el endpoint `GET /notifications/schedule` para consultar los valores actuales de estas variables.
+
+## 🚀 CI/CD
+
+El flujo definido en `.github/workflows/deploy.yml` construye las imágenes, valida las variables de horario de notificación y compila el backend. Cuando se hace push a la rama `main`, el job de despliegue ejecuta `scripts/deploy.sh`, que automatiza la construcción y el arranque de los servicios con Docker Compose.
+
+Si deseas realizar un despliegue manual, ejecuta:
+
+```bash
+./scripts/deploy.sh
+```
+
+Asegúrate de tener un archivo `.env` válido antes de lanzar el script.
+
+## 🤝 Contribuir
+
+1. Crea un fork del repositorio y una rama con un nombre descriptivo.
+2. Realiza cambios siguiendo las buenas prácticas del lenguaje o herramienta utilizada.
+3. Ejecuta `docker compose build` para confirmar que las imágenes se construyen correctamente.
+4. Abre un Pull Request describiendo claramente los cambios e incluye los resultados de las pruebas relevantes.
+
+Toda contribución es bienvenida. ¡Gracias por colaborar!

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:1.4
+FROM python:3.11-slim
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY app ./app
+
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,34 @@
+from functools import lru_cache
+from pydantic import BaseSettings, Field
+
+
+class Settings(BaseSettings):
+    database_host: str = Field(default="db", env="POSTGRES_HOST")
+    database_port: int = Field(default=5432, env="POSTGRES_PORT")
+    database_user: str = Field(default="app_user", env="POSTGRES_USER")
+    database_password: str = Field(default="app_password", env="POSTGRES_PASSWORD")
+    database_name: str = Field(default="app_db", env="POSTGRES_DB")
+
+    notification_morning_window: str = Field(
+        default="08:00-09:00", env="NOTIFICATION_MORNING_WINDOW"
+    )
+    notification_evening_window: str = Field(
+        default="18:00-19:00", env="NOTIFICATION_EVENING_WINDOW"
+    )
+    notification_timezone: str = Field(default="UTC", env="NOTIFICATION_TIMEZONE")
+
+    class Config:
+        env_file = ".env"
+        env_file_encoding = "utf-8"
+
+    @property
+    def database_url(self) -> str:
+        return (
+            f"postgresql+psycopg://{self.database_user}:{self.database_password}"
+            f"@{self.database_host}:{self.database_port}/{self.database_name}"
+        )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+
+from .config import get_settings
+
+app = FastAPI(title="Computing Backend")
+
+
+@app.get("/health", summary="Comprobar el estado del servicio")
+def read_health():
+    settings = get_settings()
+    return {
+        "status": "ok",
+        "database_url": settings.database_url,
+        "notification_timezone": settings.notification_timezone,
+    }
+
+
+@app.get(
+    "/notifications/schedule",
+    summary="Obtener ventanas horarias configuradas para las notificaciones",
+)
+def read_notification_schedule():
+    settings = get_settings()
+    return {
+        "morning": settings.notification_morning_window,
+        "evening": settings.notification_evening_window,
+        "timezone": settings.notification_timezone,
+    }

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+psycopg[binary]==3.1.18
+pydantic==1.10.14

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./backend
+    env_file:
+      - .env
+    environment:
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      POSTGRES_USER: ${POSTGRES_USER:-app_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-super-secret-password}
+      POSTGRES_DB: ${POSTGRES_DB:-app_db}
+      NOTIFICATION_MORNING_WINDOW: ${NOTIFICATION_MORNING_WINDOW:-08:00-09:00}
+      NOTIFICATION_EVENING_WINDOW: ${NOTIFICATION_EVENING_WINDOW:-18:00-19:00}
+      NOTIFICATION_TIMEZONE: ${NOTIFICATION_TIMEZONE:-UTC}
+    ports:
+      - "8000:8000"
+    depends_on:
+      - db
+
+  frontend:
+    build:
+      context: "./Desarrollo web"
+    ports:
+      - "8080:80"
+    depends_on:
+      - backend
+
+  db:
+    image: postgres:15-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-app_db}
+      POSTGRES_USER: ${POSTGRES_USER:-app_user}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-super-secret-password}
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+
+volumes:
+  db-data:

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if [ ! -f "$PROJECT_DIR/.env" ]; then
+  echo "[deploy] No se encontró un archivo .env. Copia .env.example y ajusta las credenciales antes de desplegar." >&2
+  exit 1
+fi
+
+cd "$PROJECT_DIR"
+
+echo "[deploy] Construyendo imágenes..."
+docker compose build
+
+echo "[deploy] Aplicando migraciones pendientes (placeholder)..."
+# Aquí se podrían ejecutar migraciones de la base de datos, por ejemplo con Alembic o Prisma.
+
+
+echo "[deploy] Levantando servicios en modo desprendido..."
+docker compose up -d
+
+echo "[deploy] Despliegue completado."


### PR DESCRIPTION
## Summary
- add a Docker Compose stack that builds the FastAPI backend, static frontend, and PostgreSQL database
- implement a minimal backend API that exposes notification schedule information based on environment variables
- configure deployment automation with a reusable script, GitHub Actions workflow, and updated README instructions

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_69047103a76c832492e1ee5ea62a51ec