### PR TITLE
Add inventory management frontend with Vite

### DIFF
--- a/inventory-app/.gitignore
+++ b/inventory-app/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+dist
+coverage
+.vite

--- a/inventory-app/babel.config.cjs
+++ b/inventory-app/babel.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  presets: [
+    ['@babel/preset-env', { targets: { node: 'current' } }],
+    ['@babel/preset-react', { runtime: 'automatic' }]
+  ]
+};

--- a/inventory-app/index.html
+++ b/inventory-app/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Inventario Inteligente</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/inventory-app/jest.config.cjs
+++ b/inventory-app/jest.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
+  moduleNameMapper: {
+    '\\.(css|less|scss|sass)$': 'identity-obj-proxy'
+  },
+  transform: {
+    '^.+\\.[tj]sx?$': 'babel-jest'
+  },
+  moduleFileExtensions: ['js', 'jsx']
+};

--- a/inventory-app/jest.setup.js
+++ b/inventory-app/jest.setup.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/inventory-app/package.json
+++ b/inventory-app/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "inventory-app",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview",
+    "test": "jest",
+    "test:watch": "jest --watch"
+  },
+  "dependencies": {
+    "@hookform/resolvers": "^3.3.4",
+    "@tanstack/react-query": "^5.45.1",
+    "axios": "^1.6.7",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3",
+    "react-hook-form": "^7.51.4",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@babel/preset-env": "^7.24.6",
+    "@babel/preset-react": "^7.24.6",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@vitejs/plugin-react": "^4.3.1",
+    "babel-jest": "^29.7.0",
+    "identity-obj-proxy": "^3.0.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "vite": "^5.2.0"
+  }
+}

--- a/inventory-app/src/App.jsx
+++ b/inventory-app/src/App.jsx
@@ -1,0 +1,19 @@
+import { Routes, Route } from 'react-router-dom';
+import Layout from './components/Layout.jsx';
+import DashboardPage from './pages/DashboardPage.jsx';
+import NewProductPage from './pages/NewProductPage.jsx';
+import RecipesPage from './pages/RecipesPage.jsx';
+import NotificationsPage from './pages/NotificationsPage.jsx';
+
+export default function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route index element={<DashboardPage />} />
+        <Route path="productos/nuevo" element={<NewProductPage />} />
+        <Route path="recetas" element={<RecipesPage />} />
+        <Route path="notificaciones" element={<NotificationsPage />} />
+      </Route>
+    </Routes>
+  );
+}

--- a/inventory-app/src/__tests__/InventorySummary.test.jsx
+++ b/inventory-app/src/__tests__/InventorySummary.test.jsx
@@ -1,0 +1,17 @@
+import { render, screen } from '@testing-library/react';
+import InventorySummary from '../components/InventorySummary.jsx';
+
+describe('InventorySummary', () => {
+  it('muestra los valores del resumen', () => {
+    render(
+      <InventorySummary
+        summary={{ totalItems: 42, lowStock: 5, categories: 8, inventoryValue: 1200.5 }}
+      />
+    );
+
+    expect(screen.getByText(/productos totales/i)).toBeInTheDocument();
+    expect(screen.getByText('42')).toBeInTheDocument();
+    expect(screen.getByText(/stock bajo/i)).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+  });
+});

--- a/inventory-app/src/__tests__/NotificationPanel.test.jsx
+++ b/inventory-app/src/__tests__/NotificationPanel.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import NotificationPanel from '../components/NotificationPanel.jsx';
+
+describe('NotificationPanel', () => {
+  const notifications = [
+    {
+      id: '1',
+      title: 'Reponer leche',
+      message: 'El stock de leche entera está por debajo del mínimo.',
+      date: new Date().toISOString(),
+      status: 'pending'
+    }
+  ];
+
+  it('renderiza la lista de notificaciones', () => {
+    render(<NotificationPanel notifications={notifications} onAcknowledge={jest.fn()} />);
+
+    expect(screen.getByText(/reponer leche/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /marcar como atendida/i })).toBeInTheDocument();
+    expect(screen.getByText(/pendiente/i)).toBeInTheDocument();
+  });
+
+  it('ejecuta la acción de acknowledge al pulsar el botón', () => {
+    const onAcknowledge = jest.fn();
+    render(<NotificationPanel notifications={notifications} onAcknowledge={onAcknowledge} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /marcar como atendida/i }));
+
+    expect(onAcknowledge).toHaveBeenCalledWith('1');
+  });
+});

--- a/inventory-app/src/__tests__/ProductForm.test.jsx
+++ b/inventory-app/src/__tests__/ProductForm.test.jsx
@@ -1,0 +1,37 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import ProductForm from '../components/ProductForm.jsx';
+
+describe('ProductForm', () => {
+  it('envía los datos válidos', async () => {
+    const handleSubmit = jest.fn();
+    render(<ProductForm onSubmit={handleSubmit} isSubmitting={false} />);
+
+    fireEvent.input(screen.getByLabelText(/nombre/i), { target: { value: 'Manzana' } });
+    fireEvent.input(screen.getByLabelText(/categoría/i), { target: { value: 'Frutas' } });
+    fireEvent.input(screen.getByLabelText(/stock/i), { target: { value: '10' } });
+    fireEvent.input(screen.getByLabelText(/unidad/i), { target: { value: 'kg' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /registrar producto/i }));
+
+    await waitFor(() => {
+      expect(handleSubmit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Manzana',
+          category: 'Frutas',
+          stock: 10,
+          unit: 'kg'
+        })
+      );
+    });
+  });
+
+  it('muestra mensajes de error cuando los campos son inválidos', async () => {
+    const handleSubmit = jest.fn();
+    render(<ProductForm onSubmit={handleSubmit} isSubmitting={false} />);
+
+    fireEvent.click(screen.getByRole('button', { name: /registrar producto/i }));
+
+    expect(await screen.findAllByText(/introduce un nombre válido/i)).toHaveLength(1);
+    expect(handleSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/inventory-app/src/components/InventorySummary.css
+++ b/inventory-app/src/components/InventorySummary.css
@@ -1,0 +1,30 @@
+.summary-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.summary-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.08);
+  transition: transform 0.2s ease;
+}
+
+.summary-card:hover {
+  transform: translateY(-4px);
+}
+
+.summary-card h3 {
+  margin: 0;
+  font-size: 1rem;
+  color: #475569;
+}
+
+.summary-card p {
+  margin: 0.75rem 0 0;
+  font-size: 1.8rem;
+  font-weight: 600;
+  color: #0f172a;
+}

--- a/inventory-app/src/components/InventorySummary.jsx
+++ b/inventory-app/src/components/InventorySummary.jsx
@@ -1,0 +1,25 @@
+import './InventorySummary.css';
+
+export default function InventorySummary({ summary }) {
+  if (!summary) {
+    return null;
+  }
+
+  const cards = [
+    { label: 'Productos totales', value: summary.totalItems },
+    { label: 'Stock bajo', value: summary.lowStock },
+    { label: 'Categorías activas', value: summary.categories },
+    { label: 'Valor del inventario', value: new Intl.NumberFormat('es-ES', { style: 'currency', currency: 'EUR' }).format(summary.inventoryValue ?? 0) }
+  ];
+
+  return (
+    <section className="summary-grid" aria-label="Resumen del inventario">
+      {cards.map((card) => (
+        <article key={card.label} className="summary-card">
+          <h3>{card.label}</h3>
+          <p>{card.value ?? '—'}</p>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/inventory-app/src/components/InventoryTable.css
+++ b/inventory-app/src/components/InventoryTable.css
@@ -1,0 +1,37 @@
+.table-wrapper {
+  background: #ffffff;
+  border-radius: 1rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.05);
+  overflow-x: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  text-align: left;
+  padding: 0.95rem 1.25rem;
+}
+
+th {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: #64748b;
+  border-bottom: 1px solid #e2e8f0;
+}
+
+td {
+  border-bottom: 1px solid #f1f5f9;
+}
+
+tr:last-child td {
+  border-bottom: none;
+}
+
+.row-low {
+  background: rgba(248, 113, 113, 0.1);
+}

--- a/inventory-app/src/components/InventoryTable.jsx
+++ b/inventory-app/src/components/InventoryTable.jsx
@@ -1,0 +1,42 @@
+import './InventoryTable.css';
+
+export default function InventoryTable({ items = [], isLoading }) {
+  if (isLoading) {
+    return <p>Cargando inventario...</p>;
+  }
+
+  if (!items.length) {
+    return <p>No hay productos registrados todavía.</p>;
+  }
+
+  return (
+    <div className="table-wrapper">
+      <table>
+        <thead>
+          <tr>
+            <th>Producto</th>
+            <th>Categoría</th>
+            <th>Stock</th>
+            <th>Unidad</th>
+            <th>Última actualización</th>
+          </tr>
+        </thead>
+        <tbody>
+          {items.map((item) => (
+            <tr key={item.id} className={item.status === 'low' ? 'row-low' : undefined}>
+              <td>{item.name}</td>
+              <td>{item.category}</td>
+              <td>{item.stock}</td>
+              <td>{item.unit}</td>
+              <td>
+                {item.updatedAt
+                  ? new Intl.DateTimeFormat('es-ES', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(item.updatedAt))
+                  : '—'}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/inventory-app/src/components/Layout.css
+++ b/inventory-app/src/components/Layout.css
@@ -1,0 +1,60 @@
+.app-shell {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+}
+
+.sidebar {
+  background: #0f172a;
+  color: #f8fafc;
+  padding: 2rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.logo {
+  font-size: 1.75rem;
+  margin: 0;
+}
+
+.sidebar nav {
+  display: grid;
+  gap: 1rem;
+}
+
+.sidebar a {
+  color: #e2e8f0;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  transition: background 0.2s ease;
+}
+
+.sidebar a.active,
+.sidebar a:hover {
+  background: rgba(248, 250, 252, 0.12);
+}
+
+.content {
+  padding: 2.5rem;
+  display: grid;
+  gap: 2rem;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  .sidebar nav {
+    grid-auto-flow: column;
+    overflow-x: auto;
+  }
+}

--- a/inventory-app/src/components/Layout.jsx
+++ b/inventory-app/src/components/Layout.jsx
@@ -1,0 +1,31 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import NotificationToasts from './NotificationToasts.jsx';
+import './Layout.css';
+
+export default function Layout() {
+  return (
+    <div className="app-shell">
+      <aside className="sidebar">
+        <h1 className="logo">Inventario</h1>
+        <nav>
+          <NavLink to="/" end className={({ isActive }) => (isActive ? 'active' : undefined)}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/productos/nuevo" className={({ isActive }) => (isActive ? 'active' : undefined)}>
+            Nuevo producto
+          </NavLink>
+          <NavLink to="/recetas" className={({ isActive }) => (isActive ? 'active' : undefined)}>
+            Sugerencias
+          </NavLink>
+          <NavLink to="/notificaciones" className={({ isActive }) => (isActive ? 'active' : undefined)}>
+            Notificaciones
+          </NavLink>
+        </nav>
+      </aside>
+      <main className="content">
+        <Outlet />
+      </main>
+      <NotificationToasts />
+    </div>
+  );
+}

--- a/inventory-app/src/components/NotificationPanel.css
+++ b/inventory-app/src/components/NotificationPanel.css
@@ -1,0 +1,70 @@
+.notification-panel {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.notification-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.08);
+  display: grid;
+  gap: 1rem;
+}
+
+.notification-card header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.notification-card h3 {
+  margin: 0;
+}
+
+.notification-card time {
+  font-size: 0.85rem;
+  color: #64748b;
+}
+
+.notification-card p {
+  margin: 0;
+  color: #475569;
+}
+
+.notification-card footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.status {
+  text-transform: capitalize;
+  font-weight: 600;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+}
+
+.status-pending {
+  background: #fef08a;
+}
+
+.status-done {
+  background: #bbf7d0;
+}
+
+.notification-card button {
+  border: none;
+  border-radius: 0.75rem;
+  padding: 0.65rem 1.25rem;
+  background: #0ea5e9;
+  color: #ffffff;
+  cursor: pointer;
+}
+
+.notification-card button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/inventory-app/src/components/NotificationPanel.jsx
+++ b/inventory-app/src/components/NotificationPanel.jsx
@@ -1,0 +1,40 @@
+import './NotificationPanel.css';
+
+export default function NotificationPanel({ notifications = [], onAcknowledge, isLoading, isProcessing }) {
+  if (isLoading) {
+    return <p>Cargando recordatorios...</p>;
+  }
+
+  if (!notifications.length) {
+    return <p>No hay recordatorios pendientes.</p>;
+  }
+
+  return (
+    <section className="notification-panel" aria-label="Panel de notificaciones">
+      {notifications.map((notification) => {
+        const normalizedStatus = (notification.status ?? 'pending').toLowerCase();
+        const statusLabel =
+          {
+            pending: 'pendiente',
+            done: 'completada'
+          }[normalizedStatus] ?? normalizedStatus;
+
+        return (
+          <article key={notification.id} className="notification-card">
+            <header>
+              <h3>{notification.title}</h3>
+              <time dateTime={notification.date}>{new Intl.DateTimeFormat('es-ES', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(notification.date))}</time>
+            </header>
+            <p>{notification.message}</p>
+            <footer>
+              <span className={`status status-${normalizedStatus}`}>{statusLabel}</span>
+              <button type="button" onClick={() => onAcknowledge(notification.id)} disabled={isProcessing}>
+                Marcar como atendida
+              </button>
+            </footer>
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/inventory-app/src/components/NotificationToasts.css
+++ b/inventory-app/src/components/NotificationToasts.css
@@ -1,0 +1,51 @@
+.toast-container {
+  position: fixed;
+  right: 1rem;
+  bottom: 1rem;
+  display: grid;
+  gap: 0.75rem;
+  z-index: 9999;
+}
+
+.toast {
+  min-width: 260px;
+  padding: 0.75rem 1rem;
+  border-radius: 0.5rem;
+  background: #1f2937;
+  color: #f9fafb;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.25);
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.toast-success {
+  border-left: 4px solid #22c55e;
+}
+
+.toast-error {
+  border-left: 4px solid #ef4444;
+}
+
+.toast-info {
+  border-left: 4px solid #38bdf8;
+}
+
+.toast-warning {
+  border-left: 4px solid #fbbf24;
+}
+
+.toast button {
+  border: none;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+
+.toast p {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+}

--- a/inventory-app/src/components/NotificationToasts.jsx
+++ b/inventory-app/src/components/NotificationToasts.jsx
@@ -1,0 +1,26 @@
+import './NotificationToasts.css';
+import { useNotifications } from '../context/NotificationContext.jsx';
+
+export default function NotificationToasts() {
+  const { notifications, dismissNotification } = useNotifications();
+
+  if (!notifications.length) {
+    return null;
+  }
+
+  return (
+    <div className="toast-container" role="status" aria-live="polite">
+      {notifications.map((notification) => (
+        <div key={notification.id} className={`toast toast-${notification.type ?? 'info'}`}>
+          <div>
+            <strong>{notification.title}</strong>
+            {notification.message && <p>{notification.message}</p>}
+          </div>
+          <button type="button" onClick={() => dismissNotification(notification.id)} aria-label="Cerrar notificación">
+            ×
+          </button>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/inventory-app/src/components/ProductForm.css
+++ b/inventory-app/src/components/ProductForm.css
@@ -1,0 +1,67 @@
+.product-form {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 2rem;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.06);
+  display: grid;
+  gap: 1.5rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+label {
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.95rem;
+  color: #475569;
+}
+
+input,
+select {
+  border: 1px solid #cbd5f5;
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease;
+}
+
+input:focus,
+select:focus {
+  outline: none;
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+button[type='submit'] {
+  justify-self: flex-start;
+  padding: 0.85rem 1.75rem;
+  border-radius: 0.75rem;
+  border: none;
+  background: #6366f1;
+  color: #ffffff;
+  cursor: pointer;
+  font-weight: 600;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+button[type='submit']:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 20px rgba(99, 102, 241, 0.25);
+}
+
+button[type='submit']:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
+}
+
+.errors {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: #dc2626;
+  display: grid;
+  gap: 0.35rem;
+}

--- a/inventory-app/src/components/ProductForm.jsx
+++ b/inventory-app/src/components/ProductForm.jsx
@@ -1,0 +1,77 @@
+import { useMemo } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import './ProductForm.css';
+
+const schema = z.object({
+  name: z.string().min(2, 'Introduce un nombre válido.'),
+  category: z.string().min(2, 'Selecciona una categoría.'),
+  stock: z.coerce.number().min(0, 'El stock debe ser igual o mayor a 0.'),
+  unit: z.string().min(1, 'Indica una unidad (kg, unidades, etc.)'),
+  expirationDate: z.string().optional()
+});
+
+export default function ProductForm({ onSubmit, isSubmitting }) {
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors }
+  } = useForm({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      name: '',
+      category: '',
+      stock: 0,
+      unit: 'unidades',
+      expirationDate: ''
+    }
+  });
+
+  const errorMessages = useMemo(
+    () =>
+      Object.entries(errors).map(([key, value]) => (
+        <li key={key}>{value.message}</li>
+      )),
+    [errors]
+  );
+
+  const submit = handleSubmit((data) => {
+    onSubmit(data);
+    reset();
+  });
+
+  return (
+    <form className="product-form" onSubmit={submit} noValidate>
+      <div className="form-grid">
+        <label>
+          Nombre
+          <input type="text" placeholder="Ej. Tomate pera" {...register('name')} />
+        </label>
+        <label>
+          Categoría
+          <input type="text" placeholder="Ej. Verduras" {...register('category')} />
+        </label>
+        <label>
+          Stock
+          <input type="number" min="0" step="1" {...register('stock')} />
+        </label>
+        <label>
+          Unidad
+          <input type="text" placeholder="kg, unidades..." {...register('unit')} />
+        </label>
+        <label>
+          Fecha de caducidad
+          <input type="date" {...register('expirationDate')} />
+        </label>
+      </div>
+
+      <button type="submit" disabled={isSubmitting}>
+        {isSubmitting ? 'Guardando...' : 'Registrar producto'}
+      </button>
+
+      {errorMessages.length > 0 && <ul className="errors">{errorMessages}</ul>}
+    </form>
+  );
+}

--- a/inventory-app/src/components/RecipeSuggestions.css
+++ b/inventory-app/src/components/RecipeSuggestions.css
@@ -1,0 +1,58 @@
+.recipes-grid {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.recipe-card {
+  background: #ffffff;
+  border-radius: 1rem;
+  padding: 1.5rem;
+  box-shadow: 0 15px 35px rgba(15, 23, 42, 0.07);
+  display: grid;
+  gap: 1rem;
+}
+
+.recipe-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.recipe-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.recipe-card p {
+  margin: 0;
+  color: #475569;
+}
+
+.recipe-meta ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.tag {
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  text-transform: capitalize;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #0f172a;
+  background: #e0f2fe;
+}
+
+.tag-easy {
+  background: #bbf7d0;
+}
+
+.tag-medium {
+  background: #fef9c3;
+}
+
+.tag-hard {
+  background: #fecdd3;
+}

--- a/inventory-app/src/components/RecipeSuggestions.jsx
+++ b/inventory-app/src/components/RecipeSuggestions.jsx
@@ -1,0 +1,33 @@
+import './RecipeSuggestions.css';
+
+export default function RecipeSuggestions({ recipes = [], isLoading }) {
+  if (isLoading) {
+    return <p>Buscando ideas de recetas...</p>;
+  }
+
+  if (!recipes.length) {
+    return <p>No hay sugerencias disponibles por el momento.</p>;
+  }
+
+  return (
+    <section className="recipes-grid" aria-label="Sugerencias de recetas">
+      {recipes.map((recipe) => (
+        <article key={recipe.id} className="recipe-card">
+          <header>
+            <h3>{recipe.title}</h3>
+            {recipe.difficulty && <span className={`tag tag-${recipe.difficulty}`}>{recipe.difficulty}</span>}
+          </header>
+          <p>{recipe.description}</p>
+          <div className="recipe-meta">
+            <strong>Ingredientes disponibles:</strong>
+            <ul>
+              {(recipe.availableIngredients ?? []).map((ingredient) => (
+                <li key={ingredient}>{ingredient}</li>
+              ))}
+            </ul>
+          </div>
+        </article>
+      ))}
+    </section>
+  );
+}

--- a/inventory-app/src/context/NotificationContext.jsx
+++ b/inventory-app/src/context/NotificationContext.jsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useMemo, useReducer } from 'react';
+
+const NotificationContext = createContext();
+
+const initialState = [];
+
+function reducer(state, action) {
+  switch (action.type) {
+    case 'ADD':
+      return [...state, { ...action.payload }];
+    case 'REMOVE':
+      return state.filter((notification) => notification.id !== action.payload);
+    case 'CLEAR':
+      return [];
+    default:
+      return state;
+  }
+}
+
+export function NotificationProvider({ children }) {
+  const [notifications, dispatch] = useReducer(reducer, initialState);
+
+  const showNotification = useCallback((notification) => {
+    const id =
+      notification.id ??
+      (typeof crypto !== 'undefined' && crypto.randomUUID ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`);
+    dispatch({ type: 'ADD', payload: { id, ...notification } });
+    if (!notification.persistent) {
+      setTimeout(() => {
+        dispatch({ type: 'REMOVE', payload: id });
+      }, notification.duration ?? 5000);
+    }
+  }, []);
+
+  const dismissNotification = useCallback((id) => {
+    dispatch({ type: 'REMOVE', payload: id });
+  }, []);
+
+  const value = useMemo(
+    () => ({ notifications, showNotification, dismissNotification }),
+    [notifications, showNotification, dismissNotification]
+  );
+
+  return <NotificationContext.Provider value={value}>{children}</NotificationContext.Provider>;
+}
+
+export function useNotifications() {
+  const context = useContext(NotificationContext);
+  if (!context) {
+    throw new Error('useNotifications must be used within a NotificationProvider');
+  }
+  return context;
+}

--- a/inventory-app/src/hooks/useInventory.js
+++ b/inventory-app/src/hooks/useInventory.js
@@ -1,0 +1,45 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchDashboardSummary, fetchInventory, createProduct } from '../services/inventoryService.js';
+import { useNotifications } from '../context/NotificationContext.jsx';
+
+const INVENTORY_KEY = ['inventory'];
+const SUMMARY_KEY = ['inventory-summary'];
+
+export function useInventory({ pollInterval = 10000 } = {}) {
+  const queryClient = useQueryClient();
+  const { showNotification } = useNotifications();
+
+  const inventoryQuery = useQuery({
+    queryKey: INVENTORY_KEY,
+    queryFn: fetchInventory,
+    refetchInterval: pollInterval
+  });
+
+  const summaryQuery = useQuery({
+    queryKey: SUMMARY_KEY,
+    queryFn: fetchDashboardSummary,
+    refetchInterval: pollInterval
+  });
+
+  const createProductMutation = useMutation({
+    mutationFn: createProduct,
+    onSuccess: (product) => {
+      queryClient.invalidateQueries({ queryKey: INVENTORY_KEY });
+      queryClient.invalidateQueries({ queryKey: SUMMARY_KEY });
+      showNotification({
+        type: 'success',
+        title: 'Producto registrado',
+        message: `${product.name} se añadió al inventario.`
+      });
+    },
+    onError: (error) => {
+      showNotification({
+        type: 'error',
+        title: 'Error al registrar',
+        message: error.message
+      });
+    }
+  });
+
+  return { ...inventoryQuery, summary: summaryQuery, createProduct: createProductMutation };
+}

--- a/inventory-app/src/hooks/useNotifications.js
+++ b/inventory-app/src/hooks/useNotifications.js
@@ -1,0 +1,37 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { fetchNotifications, acknowledgeNotification } from '../services/notificationService.js';
+import { useNotifications as useToastNotifications } from '../context/NotificationContext.jsx';
+
+const NOTIFICATIONS_KEY = ['notifications'];
+
+export function useServerNotifications({ pollInterval = 15000 } = {}) {
+  const queryClient = useQueryClient();
+  const { showNotification } = useToastNotifications();
+
+  const notificationsQuery = useQuery({
+    queryKey: NOTIFICATIONS_KEY,
+    queryFn: fetchNotifications,
+    refetchInterval: pollInterval
+  });
+
+  const acknowledgeMutation = useMutation({
+    mutationFn: acknowledgeNotification,
+    onSuccess: (_, id) => {
+      queryClient.invalidateQueries({ queryKey: NOTIFICATIONS_KEY });
+      showNotification({
+        type: 'success',
+        title: 'Recordatorio actualizado',
+        message: 'El recordatorio fue marcado como atendido.'
+      });
+    },
+    onError: (error) => {
+      showNotification({
+        type: 'error',
+        title: 'No se pudo actualizar',
+        message: error.message
+      });
+    }
+  });
+
+  return { ...notificationsQuery, acknowledge: acknowledgeMutation };
+}

--- a/inventory-app/src/hooks/useRecipes.js
+++ b/inventory-app/src/hooks/useRecipes.js
@@ -1,0 +1,12 @@
+import { useQuery } from '@tanstack/react-query';
+import { fetchRecipeSuggestions } from '../services/recipesService.js';
+
+const RECIPES_KEY = ['recipes'];
+
+export function useRecipes({ pollInterval = 30000 } = {}) {
+  return useQuery({
+    queryKey: RECIPES_KEY,
+    queryFn: fetchRecipeSuggestions,
+    refetchInterval: pollInterval
+  });
+}

--- a/inventory-app/src/index.css
+++ b/inventory-app/src/index.css
@@ -1,0 +1,38 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  color: #0f172a;
+  background-color: #f8fafc;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+}
+
+.page-header {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.page-header h2 {
+  margin: 0;
+  font-size: 2rem;
+}
+
+.page-header p {
+  margin: 0;
+  color: #475569;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button {
+  font: inherit;
+}

--- a/inventory-app/src/main.jsx
+++ b/inventory-app/src/main.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App.jsx';
+import { NotificationProvider } from './context/NotificationContext.jsx';
+import './index.css';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      retry: 1
+    }
+  }
+});
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <NotificationProvider>
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
+      </NotificationProvider>
+    </QueryClientProvider>
+  </React.StrictMode>
+);

--- a/inventory-app/src/pages/DashboardPage.jsx
+++ b/inventory-app/src/pages/DashboardPage.jsx
@@ -1,0 +1,19 @@
+import InventorySummary from '../components/InventorySummary.jsx';
+import InventoryTable from '../components/InventoryTable.jsx';
+import { useInventory } from '../hooks/useInventory.js';
+
+export default function DashboardPage() {
+  const { data, isLoading, summary } = useInventory();
+
+  return (
+    <section>
+      <header className="page-header">
+        <h2>Dashboard de inventario</h2>
+        <p>Consulta la disponibilidad en tiempo real y el estado general del inventario.</p>
+      </header>
+
+      <InventorySummary summary={summary.data} />
+      <InventoryTable items={data ?? []} isLoading={isLoading} />
+    </section>
+  );
+}

--- a/inventory-app/src/pages/NewProductPage.jsx
+++ b/inventory-app/src/pages/NewProductPage.jsx
@@ -1,0 +1,16 @@
+import ProductForm from '../components/ProductForm.jsx';
+import { useInventory } from '../hooks/useInventory.js';
+
+export default function NewProductPage() {
+  const { createProduct } = useInventory({ pollInterval: false });
+
+  return (
+    <section>
+      <header className="page-header">
+        <h2>Registrar nuevo producto</h2>
+        <p>Completa el formulario con la información del producto para añadirlo al inventario.</p>
+      </header>
+      <ProductForm onSubmit={createProduct.mutate} isSubmitting={createProduct.isPending} />
+    </section>
+  );
+}

--- a/inventory-app/src/pages/NotificationsPage.jsx
+++ b/inventory-app/src/pages/NotificationsPage.jsx
@@ -1,0 +1,21 @@
+import NotificationPanel from '../components/NotificationPanel.jsx';
+import { useServerNotifications } from '../hooks/useNotifications.js';
+
+export default function NotificationsPage() {
+  const { data, isLoading, acknowledge } = useServerNotifications();
+
+  return (
+    <section>
+      <header className="page-header">
+        <h2>Panel de notificaciones</h2>
+        <p>Gestiona los recordatorios y alertas asociados al inventario.</p>
+      </header>
+      <NotificationPanel
+        notifications={data ?? []}
+        isLoading={isLoading}
+        onAcknowledge={acknowledge.mutate}
+        isProcessing={acknowledge.isPending}
+      />
+    </section>
+  );
+}

--- a/inventory-app/src/pages/RecipesPage.jsx
+++ b/inventory-app/src/pages/RecipesPage.jsx
@@ -1,0 +1,16 @@
+import RecipeSuggestions from '../components/RecipeSuggestions.jsx';
+import { useRecipes } from '../hooks/useRecipes.js';
+
+export default function RecipesPage() {
+  const { data, isLoading } = useRecipes();
+
+  return (
+    <section>
+      <header className="page-header">
+        <h2>Sugerencias de recetas</h2>
+        <p>Descubre preparaciones que aprovechan los ingredientes con mayor rotación.</p>
+      </header>
+      <RecipeSuggestions recipes={data ?? []} isLoading={isLoading} />
+    </section>
+  );
+}

--- a/inventory-app/src/services/apiClient.js
+++ b/inventory-app/src/services/apiClient.js
@@ -1,0 +1,16 @@
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: import.meta.env.VITE_API_URL ?? 'https://api.example.com',
+  timeout: 8000
+});
+
+apiClient.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    const message = error.response?.data?.message ?? 'Error inesperado al comunicarse con el servidor.';
+    return Promise.reject(new Error(message));
+  }
+);
+
+export default apiClient;

--- a/inventory-app/src/services/inventoryService.js
+++ b/inventory-app/src/services/inventoryService.js
@@ -1,0 +1,16 @@
+import apiClient from './apiClient.js';
+
+export async function fetchInventory() {
+  const { data } = await apiClient.get('/inventory');
+  return data;
+}
+
+export async function createProduct(payload) {
+  const { data } = await apiClient.post('/inventory', payload);
+  return data;
+}
+
+export async function fetchDashboardSummary() {
+  const { data } = await apiClient.get('/inventory/summary');
+  return data;
+}

--- a/inventory-app/src/services/notificationService.js
+++ b/inventory-app/src/services/notificationService.js
@@ -1,0 +1,11 @@
+import apiClient from './apiClient.js';
+
+export async function fetchNotifications() {
+  const { data } = await apiClient.get('/notifications');
+  return data;
+}
+
+export async function acknowledgeNotification(id) {
+  const { data } = await apiClient.post(`/notifications/${id}/acknowledge`);
+  return data;
+}

--- a/inventory-app/src/services/recipesService.js
+++ b/inventory-app/src/services/recipesService.js
@@ -1,0 +1,6 @@
+import apiClient from './apiClient.js';
+
+export async function fetchRecipeSuggestions() {
+  const { data } = await apiClient.get('/recipes/suggestions');
+  return data;
+}

--- a/inventory-app/vite.config.js
+++ b/inventory-app/vite.config.js
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist',
+    sourcemap: true
+  },
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- initialize a Vite + React application structured with components, pages, hooks, and services for the inventory domain
- implement dashboard, product registration, recipe suggestions, and notification pages with React Query data fetching and polling
- add notification toast system, form validation, and Jest + Testing Library coverage for critical components

## Testing
- Not run (dependencies not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_69046f02d8e483249bd1f9a2bacc2c72