### PR TITLE
Add nutrition profile frontend form and FastAPI endpoints

### DIFF
--- a/Desarrollo web/menu.html
+++ b/Desarrollo web/menu.html
@@ -28,6 +28,7 @@
     <a href="menu.html" class="w3-bar-item w3-button w3-hover-red">Home</a>
     <a href="EventList" class="w3-bar-item w3-button w3-hide-small w3-hover-red"> Events</a>
     <a href="contactanos.html" class="w3-bar-item w3-button w3-hide-small w3-hover-red"> Contact Us</a>
+    <a href="perfil.html" class="w3-bar-item w3-button w3-hide-small w3-hover-red"> Perfil</a>
     <a href="menu.html#about" class="w3-bar-item w3-button w3-hide-small w3-hover-red"> About Us</a>
 
 

--- a/Desarrollo web/perfil.html
+++ b/Desarrollo web/perfil.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Perfil de Nutrición</title>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Montserrat">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body class="profile-page">
+    <header class="profile-header">
+        <h1>Tu perfil de salud</h1>
+        <p>Completa tus datos para personalizar las recomendaciones nutricionales.</p>
+    </header>
+
+    <main class="profile-container">
+        <form id="profile-form" class="profile-form">
+            <div class="form-group">
+                <label for="weight">Peso (kg)</label>
+                <input type="number" step="0.1" min="0" id="weight" name="weight" placeholder="Ej. 70" required>
+            </div>
+            <div class="form-group">
+                <label for="height">Altura (cm)</label>
+                <input type="number" step="0.1" min="0" id="height" name="height" placeholder="Ej. 175" required>
+            </div>
+            <div class="form-group full-width">
+                <label for="goals">Objetivos</label>
+                <textarea id="goals" name="goals" rows="4" placeholder="Describe tus objetivos nutricionales o de entrenamiento"></textarea>
+            </div>
+            <div class="form-group full-width">
+                <label for="dietary_restrictions">Restricciones alimentarias</label>
+                <textarea id="dietary_restrictions" name="dietary_restrictions" rows="4" placeholder="Incluye alergias, preferencias o restricciones"></textarea>
+            </div>
+            <div class="form-actions">
+                <button type="submit" class="primary-button">Guardar cambios</button>
+            </div>
+        </form>
+        <p id="feedback-message" class="feedback-message" role="status" aria-live="polite"></p>
+    </main>
+
+    <script>
+    (function() {
+        const PROFILE_ID = 1;
+        const API_BASE_URL = window.profileApiBaseUrl || 'http://localhost:8000';
+        const form = document.getElementById('profile-form');
+        const feedback = document.getElementById('feedback-message');
+
+        function setFeedback(message, type = 'info') {
+            feedback.textContent = message;
+            feedback.className = `feedback-message ${type}`;
+        }
+
+        async function loadProfile() {
+            try {
+                const response = await fetch(`${API_BASE_URL}/profile/${PROFILE_ID}`);
+                if (!response.ok) {
+                    throw new Error('No se pudo cargar el perfil.');
+                }
+                const data = await response.json();
+                document.getElementById('weight').value = data.weight ?? '';
+                document.getElementById('height').value = data.height ?? '';
+                document.getElementById('goals').value = data.goals ?? '';
+                document.getElementById('dietary_restrictions').value = data.dietary_restrictions ?? '';
+            } catch (error) {
+                console.error(error);
+                setFeedback('Ocurrió un error al cargar tus datos. Inténtalo nuevamente.', 'error');
+            }
+        }
+
+        form.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            setFeedback('Guardando información…', 'pending');
+
+            const payload = {
+                weight: form.weight.value ? Number(form.weight.value) : null,
+                height: form.height.value ? Number(form.height.value) : null,
+                goals: form.goals.value.trim() || null,
+                dietary_restrictions: form.dietary_restrictions.value.trim() || null,
+            };
+
+            try {
+                const response = await fetch(`${API_BASE_URL}/profile/${PROFILE_ID}`, {
+                    method: 'PUT',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    },
+                    body: JSON.stringify(payload),
+                });
+
+                if (!response.ok) {
+                    throw new Error('No se pudo guardar el perfil.');
+                }
+
+                const data = await response.json();
+                document.getElementById('weight').value = data.weight ?? '';
+                document.getElementById('height').value = data.height ?? '';
+                document.getElementById('goals').value = data.goals ?? '';
+                document.getElementById('dietary_restrictions').value = data.dietary_restrictions ?? '';
+                setFeedback('Perfil guardado correctamente.', 'success');
+            } catch (error) {
+                console.error(error);
+                setFeedback('Ocurrió un error al guardar tus datos. Inténtalo nuevamente.', 'error');
+            }
+        });
+
+        loadProfile();
+    })();
+    </script>
+</body>
+</html>

--- a/Desarrollo web/style.css
+++ b/Desarrollo web/style.css
@@ -90,3 +90,125 @@ body, html {
 .star-rating span:nth-child(5) {
     width: 100%;
 }
+
+/* Profile form layout */
+.profile-page {
+  font-family: "Montserrat", sans-serif;
+  background: #f5f7fb;
+  margin: 0;
+  padding: 0;
+  color: #2f2f2f;
+}
+
+.profile-header {
+  text-align: center;
+  padding: 3rem 1rem 2rem;
+  background: linear-gradient(135deg, #ff6f61, #ff9966);
+  color: #fff;
+}
+
+.profile-container {
+  max-width: 720px;
+  margin: -2rem auto 3rem;
+  background: #fff;
+  border-radius: 16px;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.1);
+  padding: 2.5rem 3rem;
+}
+
+.profile-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem 2rem;
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+}
+
+.form-group label {
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.form-group input,
+.form-group textarea {
+  border: 1px solid #d9dce3;
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.form-group input:focus,
+.form-group textarea:focus {
+  border-color: #ff6f61;
+  box-shadow: 0 0 0 3px rgba(255, 111, 97, 0.2);
+  outline: none;
+}
+
+.form-group textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+
+.form-group.full-width {
+  grid-column: 1 / -1;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.primary-button {
+  background: linear-gradient(135deg, #ff6f61, #ff9966);
+  border: none;
+  border-radius: 999px;
+  color: #fff;
+  padding: 0.85rem 2.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.primary-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 18px rgba(255, 111, 97, 0.35);
+}
+
+.feedback-message {
+  margin-top: 1.5rem;
+  text-align: center;
+  font-weight: 500;
+}
+
+.feedback-message.success {
+  color: #1b9e50;
+}
+
+.feedback-message.error {
+  color: #d64545;
+}
+
+.feedback-message.pending {
+  color: #f39c12;
+}
+
+@media (max-width: 640px) {
+  .profile-container {
+    margin: -3rem 1rem 2rem;
+    padding: 2rem 1.5rem;
+  }
+
+  .form-actions {
+    justify-content: center;
+  }
+
+  .primary-button {
+    width: 100%;
+  }
+}

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Los servicios expuestos son:
 | Servicio   | Puerto local | Descripción |
 |------------|--------------|-------------|
 | Frontend   | `http://localhost:8080` | Sitio estático contenido en `Desarrollo web/` servido con Nginx. |
-| Backend    | `http://localhost:8000` | API FastAPI con endpoints de salud y consulta de horarios de notificación. |
+| Backend    | `http://localhost:8000` | API FastAPI con endpoints de salud, perfil nutricional y consulta de horarios de notificación. |
 | Base de datos | `localhost:5432` | Instancia PostgreSQL con volúmenes persistentes. |
 
 Para detener los servicios ejecuta:
@@ -52,6 +52,15 @@ docker compose down
 | `NOTIFICATION_TIMEZONE` | Zona horaria que se empleará al interpretar las ventanas configuradas. |
 
 El backend expone el endpoint `GET /notifications/schedule` para consultar los valores actuales de estas variables.
+
+### Perfil nutricional
+
+El servicio de FastAPI incluye un recurso `/profile/{profile_id}` que permite persistir métricas y preferencias del usuario:
+
+* `GET /profile/{profile_id}` devuelve (y crea si no existe) el perfil con peso, altura, objetivos y restricciones alimentarias.
+* `PUT /profile/{profile_id}` actualiza el perfil con los datos enviados en el cuerpo de la petición.
+
+Por defecto la aplicación utiliza SQLite (`backend/app/data/app.db`), aunque se puede establecer la variable de entorno `PROFILE_DATABASE_URL` para apuntar a otra base de datos compatible con SQLAlchemy.
 
 ## 🚀 CI/CD
 

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,4 @@
+"""Nutrition profile backend package."""
+
+__all__ = ["__version__"]
+__version__ = "0.1.0"

--- a/backend/app/api/__init__.py
+++ b/backend/app/api/__init__.py
@@ -1,0 +1,4 @@
+"""Route packages for the nutrition profile API."""
+from . import profile
+
+__all__ = ["profile"]

--- a/backend/app/api/profile.py
+++ b/backend/app/api/profile.py
@@ -1,0 +1,31 @@
+"""API routes for user profile operations."""
+from __future__ import annotations
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from .. import crud, schemas
+from ..database import get_session
+
+router = APIRouter(prefix="/profile", tags=["profile"])
+
+
+@router.get("/{profile_id}", response_model=schemas.Profile)
+def read_profile(profile_id: int, db: Session = Depends(get_session)):
+    """Return the profile data for the given identifier."""
+    profile = crud.get_or_create_profile(db, profile_id)
+    return profile
+
+
+@router.put("/{profile_id}", response_model=schemas.Profile, status_code=status.HTTP_200_OK)
+def update_profile(
+    profile_id: int,
+    payload: schemas.ProfileUpdate,
+    db: Session = Depends(get_session),
+):
+    """Create or update the profile with the provided information."""
+    if payload is None:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Datos no proporcionados")
+
+    profile = crud.upsert_profile(db, profile_id, payload)
+    return profile

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,0 +1,32 @@
+"""Data access helpers for the nutrition profile API."""
+from __future__ import annotations
+
+from sqlalchemy.orm import Session
+
+from . import models, schemas
+
+
+def get_profile(db: Session, profile_id: int) -> models.UserProfile | None:
+    return db.query(models.UserProfile).filter(models.UserProfile.id == profile_id).first()
+
+
+def get_or_create_profile(db: Session, profile_id: int) -> models.UserProfile:
+    profile = get_profile(db, profile_id)
+    if profile is None:
+        profile = models.UserProfile(id=profile_id)
+        db.add(profile)
+        db.commit()
+        db.refresh(profile)
+    return profile
+
+
+def upsert_profile(db: Session, profile_id: int, payload: schemas.ProfileUpdate) -> models.UserProfile:
+    profile = get_profile(db, profile_id)
+    if profile is None:
+        profile = models.UserProfile(id=profile_id)
+        db.add(profile)
+
+    profile.update_from_dict(payload.dict(exclude_unset=True))
+    db.commit()
+    db.refresh(profile)
+    return profile

--- a/backend/app/data/.gitignore
+++ b/backend/app/data/.gitignore
@@ -1,0 +1,3 @@
+# Ignore generated SQLite database files
+*.db
+*.db-journal

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,46 @@
+"""Database configuration utilities for the nutrition profile service."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Generator
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+DEFAULT_SQLITE_PATH = Path(__file__).resolve().parent / "data" / "app.db"
+
+def _build_database_url() -> str:
+    """Return the database URL, defaulting to a local SQLite file."""
+    url = os.getenv("PROFILE_DATABASE_URL")
+    if url:
+        return url
+
+    data_dir = DEFAULT_SQLITE_PATH.parent
+    data_dir.mkdir(parents=True, exist_ok=True)
+    return f"sqlite:///{DEFAULT_SQLITE_PATH}"
+
+DATABASE_URL = _build_database_url()
+
+connect_args = {"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {}
+
+engine = create_engine(DATABASE_URL, connect_args=connect_args, future=True)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine, future=True)
+
+Base = declarative_base()
+
+
+def get_session() -> Generator:
+    """Yield a database session that closes automatically."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def init_db() -> None:
+    """Create all tables if they do not exist yet."""
+    from . import models  # noqa: F401  Ensure models are registered
+
+    Base.metadata.create_all(bind=engine)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,31 @@
+"""FastAPI application exposing profile endpoints for the nutrition app."""
+from __future__ import annotations
+
+import os
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from .api import profile
+from .database import init_db
+
+app = FastAPI(title="Nutrition Profile API", version="0.1.0")
+
+allowed_origins = [origin.strip() for origin in os.getenv("CORS_ALLOWED_ORIGINS", "*").split(",")]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allowed_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+init_db()
+app.include_router(profile.router)
+
+
+@app.get("/health", tags=["health"]) 
+def health_check() -> dict[str, str]:
+    """Simple endpoint to confirm the service is running."""
+    return {"status": "ok"}

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,27 @@
+"""SQLAlchemy models for the nutrition profile domain."""
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Float, Integer, Text
+
+from .database import Base
+
+
+class UserProfile(Base):
+    """Store anthropometric data and preferences for a user."""
+
+    __tablename__ = "user_profiles"
+
+    id = Column(Integer, primary_key=True, index=True)
+    weight = Column(Float, nullable=True)
+    height = Column(Float, nullable=True)
+    goals = Column(Text, nullable=True)
+    dietary_restrictions = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    def update_from_dict(self, data: dict[str, object]) -> None:
+        """Apply updates using a dict produced by a Pydantic model."""
+        for key, value in data.items():
+            setattr(self, key, value)

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for request and response bodies."""
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field, validator
+
+
+class ProfileBase(BaseModel):
+    weight: Optional[float] = Field(None, description="Peso corporal en kilogramos")
+    height: Optional[float] = Field(None, description="Altura en centímetros")
+    goals: Optional[str] = Field(None, description="Objetivos personales o deportivos")
+    dietary_restrictions: Optional[str] = Field(None, description="Restricciones o preferencias alimentarias")
+
+    @validator("weight", "height")
+    def _validate_positive(cls, value: Optional[float]) -> Optional[float]:
+        if value is not None and value <= 0:
+            raise ValueError("El valor debe ser mayor que cero")
+        return value
+
+
+class ProfileUpdate(ProfileBase):
+    """Schema used to update or create a profile."""
+
+
+class Profile(ProfileBase):
+    id: int
+    created_at: datetime
+    updated_at: datetime
+
+    class Config:
+        orm_mode = True

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110.0
+uvicorn[standard]>=0.23.0
+sqlalchemy>=2.0.0
+pydantic>=1.10.0,<2.0.0


### PR DESCRIPTION
## Summary
- add a nutrition profile form to the frontend and wire it to the API
- implement FastAPI models, routes, and persistence for storing profile metrics and preferences
- document the new profile endpoints in the README

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_6905e9b4df0c83249fbea374f59fcdaa