### PR TITLE
Add virtual fridge UI and FastAPI backend with receipt OCR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+*.py[cod]
+.env
+.env.*
+.DS_Store

--- a/Desarrollo web/virtual-fridge/app.js
+++ b/Desarrollo web/virtual-fridge/app.js
@@ -1,0 +1,332 @@
+const API_BASE = window.APP_CONFIG?.API_BASE ?? "http://localhost:8000/api";
+
+const inventoryBody = document.getElementById("inventory-body");
+const inventorySearch = document.getElementById("inventory-search");
+const manualEntryForm = document.getElementById("manual-entry-form");
+const receiptTextForm = document.getElementById("receipt-text-form");
+const receiptScanForm = document.getElementById("receipt-scan-form");
+const receiptResults = document.getElementById("receipt-results");
+const receiptWarnings = document.getElementById("receipt-warnings");
+const receiptItemsBody = document.getElementById("receipt-items-body");
+const receiptItemsForm = document.getElementById("receipt-items-form");
+const recipesList = document.getElementById("recipes");
+const apiStatus = document.getElementById("api-status");
+
+let currentInventory = [];
+let receiptItems = [];
+
+function formatQuantity(value, unit) {
+  const formatter = new Intl.NumberFormat("es-ES", { maximumFractionDigits: 2 });
+  return `${formatter.format(value)} ${unit}`;
+}
+
+function updateApiStatus(connected) {
+  if (connected) {
+    apiStatus.textContent = "Backend disponible";
+    apiStatus.classList.add("connected");
+  } else {
+    apiStatus.textContent = "Sin conexión con el backend";
+    apiStatus.classList.remove("connected");
+  }
+}
+
+async function fetchInventory() {
+  try {
+    const response = await fetch(`${API_BASE}/inventory`);
+    if (!response.ok) throw new Error("Error al obtener inventario");
+    const data = await response.json();
+    currentInventory = data;
+    renderInventory(data);
+    updateApiStatus(true);
+  } catch (error) {
+    console.error(error);
+    updateApiStatus(false);
+  }
+}
+
+async function fetchRecipes() {
+  try {
+    const response = await fetch(`${API_BASE}/recipes`);
+    if (!response.ok) throw new Error("Error al obtener recetas");
+    const data = await response.json();
+    renderRecipes(data);
+  } catch (error) {
+    console.error(error);
+  }
+}
+
+function createInventoryRow(item) {
+  const template = document.getElementById("inventory-row-template");
+  const row = template.content.firstElementChild.cloneNode(true);
+  row.dataset.itemId = item.id;
+  row.querySelector(".inventory-name").textContent = item.product_name;
+  row.querySelector(".quantity-input").value = item.quantity;
+  row.querySelector(".unit").textContent = item.unit;
+  if (item.expires_at) {
+    row.querySelector(".date-input").value = item.expires_at;
+  }
+  if (item.notes) {
+    row.querySelector(".notes-input").value = item.notes;
+  }
+  return row;
+}
+
+function renderInventory(products) {
+  inventoryBody.innerHTML = "";
+  const filter = inventorySearch.value.toLowerCase();
+  products
+    .filter((product) => product.product_name.toLowerCase().includes(filter))
+    .forEach((product) => {
+      const groupedRow = document.createElement("tr");
+      groupedRow.classList.add("group-row");
+      groupedRow.innerHTML = `
+        <td>${product.product_name}</td>
+        <td>${formatQuantity(product.total_quantity, product.unit)}</td>
+        <td colspan="3">${product.reorder_threshold ? `Umbral: ${product.reorder_threshold} ${product.unit}` : ""}</td>
+      `;
+      inventoryBody.appendChild(groupedRow);
+
+      product.items.forEach((item) => {
+        const row = createInventoryRow(item);
+        inventoryBody.appendChild(row);
+      });
+    });
+}
+
+function renderRecipes(recipes) {
+  recipesList.innerHTML = "";
+  if (recipes.length === 0) {
+    recipesList.innerHTML = "<li>No hay recetas configuradas todavía.</li>";
+    return;
+  }
+
+  recipes.forEach((recipe) => {
+    const li = document.createElement("li");
+    li.classList.add("recipe-card");
+    li.innerHTML = `
+      <div class="recipe-card__header">
+        <h3>${recipe.name}</h3>
+        <span class="recipe-card__status ${recipe.can_make ? "available" : "missing"}">
+          ${recipe.can_make ? "Disponible" : "Faltan ingredientes"}
+        </span>
+      </div>
+      <p>${recipe.description ?? ""}</p>
+      <p><strong>Raciones:</strong> ${recipe.servings}</p>
+      ${recipe.instructions ? `<p>${recipe.instructions}</p>` : ""}
+      ${
+        recipe.missing_ingredients.length
+          ? `<div><p>Ingredientes faltantes:</p><ul class="missing-list">${recipe.missing_ingredients
+              .map(
+                (missing) =>
+                  `<li>${missing.product_name}: ${missing.required_quantity} ${missing.unit} (disponible: ${missing.available_quantity})</li>`
+              )
+              .join("")}</ul></div>`
+          : ""
+      }
+    `;
+    recipesList.appendChild(li);
+  });
+}
+
+async function handleManualEntry(event) {
+  event.preventDefault();
+  const formData = new FormData(manualEntryForm);
+  const payload = [
+    {
+      product_name: formData.get("product"),
+      quantity: Number(formData.get("quantity")),
+      unit: formData.get("unit"),
+      expires_at: formData.get("expires_at") || null,
+      notes: formData.get("notes") || null,
+    },
+  ];
+
+  try {
+    const response = await fetch(`${API_BASE}/inventory/items`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) throw new Error("No se pudo registrar el alimento");
+    manualEntryForm.reset();
+    await fetchInventory();
+    await fetchRecipes();
+  } catch (error) {
+    console.error(error);
+    alert("Error al guardar el alimento. Revisa la consola para más detalles.");
+  }
+}
+
+async function handleUpdateItem(button) {
+  const row = button.closest("tr");
+  const itemId = row.dataset.itemId;
+  const quantityInput = row.querySelector(".quantity-input");
+  const dateInput = row.querySelector(".date-input");
+  const notesInput = row.querySelector(".notes-input");
+
+  const payload = {
+    quantity: Number(quantityInput.value),
+    expires_at: dateInput.value || null,
+    notes: notesInput.value || null,
+  };
+
+  try {
+    const response = await fetch(`${API_BASE}/inventory/items/${itemId}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) throw new Error("No se pudo actualizar el alimento");
+    await fetchInventory();
+    await fetchRecipes();
+  } catch (error) {
+    console.error(error);
+    alert("Error al actualizar el alimento.");
+  }
+}
+
+function renderReceiptItems(items) {
+  receiptItemsBody.innerHTML = "";
+  items.forEach((item, index) => {
+    const row = document.createElement("tr");
+    row.innerHTML = `
+      <td><input type="text" name="product_${index}" value="${item.product_name}" required /></td>
+      <td><input type="number" step="0.01" min="0" name="quantity_${index}" value="${item.quantity}" required /></td>
+      <td>
+        <select name="unit_${index}">
+          <option value="unidad" ${item.unit === "unidad" ? "selected" : ""}>Unidad</option>
+          <option value="kg" ${item.unit === "kg" ? "selected" : ""}>Kg</option>
+          <option value="g" ${item.unit === "g" ? "selected" : ""}>Gramos</option>
+          <option value="l" ${item.unit === "l" ? "selected" : ""}>Litros</option>
+          <option value="ml" ${item.unit === "ml" ? "selected" : ""}>Mililitros</option>
+        </select>
+      </td>
+      <td><button type="button" class="button small" data-action="remove" data-index="${index}">Eliminar</button></td>
+    `;
+    receiptItemsBody.appendChild(row);
+  });
+}
+
+function showReceiptResults(result) {
+  receiptItems = result.items;
+  renderReceiptItems(receiptItems);
+  receiptWarnings.textContent = result.warnings.join(" • ") || "";
+  receiptResults.classList.toggle("hidden", receiptItems.length === 0);
+}
+
+async function parseReceiptText(event) {
+  event.preventDefault();
+  const text = new FormData(receiptTextForm).get("receipt_text");
+  try {
+    const response = await fetch(`${API_BASE}/inventory/receipt/parse-text`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text }),
+    });
+    if (!response.ok) throw new Error("No se pudo interpretar el ticket");
+    const data = await response.json();
+    showReceiptResults(data);
+  } catch (error) {
+    console.error(error);
+    alert("No se pudo interpretar el ticket. Comprueba el formato del texto.");
+  }
+}
+
+async function scanReceipt(event) {
+  event.preventDefault();
+  const formData = new FormData(receiptScanForm);
+  const file = formData.get("receipt_image");
+  if (!file) {
+    alert("Selecciona una imagen del ticket");
+    return;
+  }
+  try {
+    const response = await fetch(`${API_BASE}/inventory/receipt/scan`, {
+      method: "POST",
+      body: formData,
+    });
+    if (!response.ok) throw new Error("Error al procesar la imagen");
+    const data = await response.json();
+    showReceiptResults(data);
+  } catch (error) {
+    console.error(error);
+    alert("No se pudo escanear el ticket. Asegúrate de que el backend tenga OCR disponible.");
+  }
+}
+
+function removeReceiptItem(index) {
+  receiptItems.splice(index, 1);
+  renderReceiptItems(receiptItems);
+  if (receiptItems.length === 0) {
+    receiptResults.classList.add("hidden");
+  }
+}
+
+async function commitReceiptItems(event) {
+  event.preventDefault();
+  if (receiptItems.length === 0) return;
+
+  const updatedItems = receiptItems.map((item, index) => {
+    const row = receiptItemsBody.children[index];
+    return {
+      product_name: row.querySelector(`input[name="product_${index}"]`).value,
+      quantity: Number(row.querySelector(`input[name="quantity_${index}"]`).value),
+      unit: row.querySelector(`select[name="unit_${index}"]`).value,
+    };
+  });
+
+  try {
+    const response = await fetch(`${API_BASE}/inventory/receipt/commit`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ items: updatedItems }),
+    });
+    if (!response.ok) throw new Error("No se pudo guardar el ticket");
+    receiptResults.classList.add("hidden");
+    receiptItems = [];
+    receiptItemsBody.innerHTML = "";
+    await fetchInventory();
+    await fetchRecipes();
+  } catch (error) {
+    console.error(error);
+    alert("Error al guardar los artículos del ticket");
+  }
+}
+
+function setupTabs() {
+  const buttons = document.querySelectorAll(".tab-button");
+  const contents = document.querySelectorAll(".tab-content");
+
+  buttons.forEach((button) => {
+    button.addEventListener("click", () => {
+      const target = button.dataset.tab;
+      buttons.forEach((btn) => btn.classList.toggle("active", btn === button));
+      contents.forEach((content) =>
+        content.classList.toggle("active", content.dataset.content === target)
+      );
+    });
+  });
+}
+
+inventoryBody.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-action='save']");
+  if (button) {
+    handleUpdateItem(button);
+  }
+});
+
+receiptItemsBody.addEventListener("click", (event) => {
+  const button = event.target.closest("button[data-action='remove']");
+  if (!button) return;
+  removeReceiptItem(Number(button.dataset.index));
+});
+
+manualEntryForm.addEventListener("submit", handleManualEntry);
+receiptTextForm.addEventListener("submit", parseReceiptText);
+receiptScanForm.addEventListener("submit", scanReceipt);
+receiptItemsForm.addEventListener("submit", commitReceiptItems);
+inventorySearch.addEventListener("input", () => renderInventory(currentInventory));
+
+setupTabs();
+fetchInventory();
+fetchRecipes();

--- a/Desarrollo web/virtual-fridge/index.html
+++ b/Desarrollo web/virtual-fridge/index.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="es">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Nevera virtual</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Nevera virtual</h1>
+        <p>Gestiona los alimentos disponibles, registra nuevas compras y descubre recetas posibles.</p>
+      </div>
+      <div class="status" id="api-status">Comprobando conexión…</div>
+    </header>
+
+    <main class="layout">
+      <section class="panel">
+        <header class="panel__header">
+          <h2>Inventario actual</h2>
+          <input type="search" id="inventory-search" placeholder="Buscar producto…" />
+        </header>
+        <div class="panel__content">
+          <table class="inventory-table" id="inventory-table">
+            <thead>
+              <tr>
+                <th>Producto</th>
+                <th>Total</th>
+                <th>Caducidad</th>
+                <th>Notas</th>
+                <th>Acciones</th>
+              </tr>
+            </thead>
+            <tbody id="inventory-body"></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section class="panel">
+        <header class="panel__header">
+          <h2>Añadir alimentos</h2>
+        </header>
+        <div class="panel__content">
+          <form id="manual-entry-form" class="form-grid">
+            <label>
+              <span>Producto</span>
+              <input type="text" name="product" required />
+            </label>
+            <label>
+              <span>Cantidad</span>
+              <input type="number" step="0.01" name="quantity" min="0" required />
+            </label>
+            <label>
+              <span>Unidad</span>
+              <select name="unit">
+                <option value="unidad">Unidad</option>
+                <option value="kg">Kg</option>
+                <option value="g">Gramos</option>
+                <option value="l">Litros</option>
+                <option value="ml">Mililitros</option>
+              </select>
+            </label>
+            <label>
+              <span>Caducidad (opcional)</span>
+              <input type="date" name="expires_at" />
+            </label>
+            <label class="full-width">
+              <span>Notas</span>
+              <textarea name="notes" rows="2" placeholder="Ej. Ubicación en la nevera"></textarea>
+            </label>
+            <button type="submit" class="button primary">Guardar</button>
+          </form>
+        </div>
+      </section>
+
+      <section class="panel">
+        <header class="panel__header">
+          <h2>Ticket de compra</h2>
+          <nav class="tab-nav">
+            <button data-tab="text" class="tab-button active">Pegar texto</button>
+            <button data-tab="scan" class="tab-button">Escanear ticket</button>
+          </nav>
+        </header>
+        <div class="panel__content">
+          <div class="tab-content active" data-content="text">
+            <form id="receipt-text-form" class="form-grid">
+              <label class="full-width">
+                <span>Texto del ticket</span>
+                <textarea name="receipt_text" rows="6" placeholder="Pega el texto reconocido del ticket"></textarea>
+              </label>
+              <button type="submit" class="button">Interpretar ticket</button>
+            </form>
+          </div>
+          <div class="tab-content" data-content="scan">
+            <form id="receipt-scan-form" class="form-grid" enctype="multipart/form-data">
+              <label class="full-width">
+                <span>Imagen del ticket</span>
+                <input type="file" name="receipt_image" accept="image/*" />
+              </label>
+              <button type="submit" class="button">Escanear ticket</button>
+              <p class="help">Se usa Tesseract OCR. Si el backend no tiene el binario instalado se mostrará un aviso.</p>
+            </form>
+          </div>
+
+          <section id="receipt-results" class="receipt-results hidden">
+            <header>
+              <h3>Resultado del ticket</h3>
+              <p id="receipt-warnings"></p>
+            </header>
+            <form id="receipt-items-form">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Producto</th>
+                    <th>Cantidad</th>
+                    <th>Unidad</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody id="receipt-items-body"></tbody>
+              </table>
+              <button type="submit" class="button primary">Añadir al inventario</button>
+            </form>
+          </section>
+        </div>
+      </section>
+
+      <section class="panel">
+        <header class="panel__header">
+          <h2>Recetas recomendadas</h2>
+        </header>
+        <div class="panel__content">
+          <ul class="recipes" id="recipes"></ul>
+        </div>
+      </section>
+    </main>
+
+    <template id="inventory-row-template">
+      <tr>
+        <td class="inventory-name"></td>
+        <td>
+          <div class="quantity-editor">
+            <input type="number" class="quantity-input" step="0.01" min="0" />
+            <span class="unit"></span>
+          </div>
+        </td>
+        <td><input type="date" class="date-input" /></td>
+        <td><input type="text" class="notes-input" placeholder="Notas" /></td>
+        <td>
+          <button class="button small" data-action="save">Guardar</button>
+        </td>
+      </tr>
+    </template>
+
+    <script src="app.js" type="module"></script>
+  </body>
+</html>

--- a/Desarrollo web/virtual-fridge/styles.css
+++ b/Desarrollo web/virtual-fridge/styles.css
@@ -1,0 +1,303 @@
+:root {
+  color-scheme: light;
+  --bg: #f5f6fb;
+  --panel: #ffffff;
+  --border: #d6dae5;
+  --accent: #3478f6;
+  --accent-dark: #1f5cc4;
+  --text: #20253a;
+  --muted: #5d6380;
+  --success: #1f9d55;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--bg);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5rem 2rem;
+  background: var(--panel);
+  border-bottom: 1px solid var(--border);
+  box-shadow: 0 4px 12px rgba(22, 27, 45, 0.08);
+}
+
+.app-header h1 {
+  margin: 0 0 0.25rem;
+}
+
+.app-header p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.status {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.status.connected {
+  color: var(--success);
+}
+
+.layout {
+  display: grid;
+  gap: 1.5rem;
+  padding: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+}
+
+.panel {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  display: flex;
+  flex-direction: column;
+  min-height: 260px;
+  box-shadow: 0 10px 24px rgba(22, 27, 45, 0.08);
+}
+
+.panel__header {
+  padding: 1.25rem 1.5rem;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.panel__header h2 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.panel__content {
+  padding: 1.5rem;
+  flex: 1;
+  overflow: auto;
+}
+
+.inventory-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.95rem;
+}
+
+.inventory-table th,
+.inventory-table td {
+  padding: 0.6rem 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.inventory-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.inventory-table .group-row td {
+  background: rgba(32, 37, 58, 0.04);
+  font-weight: 600;
+}
+
+.quantity-editor {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+}
+
+.quantity-editor input {
+  width: 5rem;
+}
+
+.button {
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 0.5rem 0.9rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  color: var(--text);
+}
+
+.button:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.button.primary {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.button.primary:hover {
+  background: var(--accent-dark);
+  border-color: var(--accent-dark);
+}
+
+.button.small {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.7rem;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1rem;
+}
+
+.form-grid label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.form-grid input,
+.form-grid select,
+.form-grid textarea {
+  padding: 0.45rem 0.55rem;
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  font-size: 0.95rem;
+  font-family: inherit;
+}
+
+.form-grid textarea {
+  resize: vertical;
+}
+
+.form-grid .full-width {
+  grid-column: 1 / -1;
+}
+
+.tab-nav {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.tab-button {
+  border: none;
+  background: transparent;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-weight: 500;
+  cursor: pointer;
+  border: 1px solid transparent;
+}
+
+.tab-button.active {
+  background: rgba(52, 120, 246, 0.12);
+  border-color: rgba(52, 120, 246, 0.2);
+  color: var(--accent-dark);
+}
+
+.tab-content {
+  display: none;
+  margin-bottom: 1rem;
+}
+
+.tab-content.active {
+  display: block;
+}
+
+.help {
+  font-size: 0.85rem;
+  color: var(--muted);
+  margin: 0;
+}
+
+.receipt-results {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  margin-top: 1rem;
+  background: rgba(52, 120, 246, 0.04);
+}
+
+.receipt-results.hidden {
+  display: none;
+}
+
+.receipt-results table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.receipt-results th,
+.receipt-results td {
+  padding: 0.4rem 0.3rem;
+  border-bottom: 1px solid rgba(52, 120, 246, 0.1);
+}
+
+.receipt-results tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.recipes {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.recipe-card {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.5rem;
+  background: rgba(32, 37, 58, 0.02);
+}
+
+.recipe-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.recipe-card__status {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.recipe-card__status.available {
+  color: var(--success);
+}
+
+.recipe-card__status.missing {
+  color: #d64545;
+}
+
+.missing-list {
+  margin: 0;
+  padding-left: 1.2rem;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .panel__header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .quantity-editor input {
+    width: 100%;
+  }
+}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,19 @@ Para detener los servicios ejecuta:
 docker compose down
 ```
 
+### Nevera virtual
+
+El directorio `backend/` incluye una API en FastAPI que implementa la lógica de la nevera virtual: inventario de alimentos, registro manual, interpretación de tickets mediante OCR y sugerencia de recetas.
+
+```bash
+pip install -r backend/requirements.txt
+uvicorn app.main:app --reload --app-dir backend
+```
+
+Por defecto la API se expone en `http://localhost:8000/api`. Desde el navegador puedes abrir `Desarrollo web/virtual-fridge/index.html` (sirviéndolo con cualquier servidor estático) para gestionar la UI del inventario. Ajusta la variable global `APP_CONFIG.API_BASE` si publicas backend y frontend en hosts distintos.
+
+> ℹ️ Para habilitar el escaneo de tickets instala el binario `tesseract-ocr` en el sistema donde se ejecute el backend.
+
 ### Variables de entorno relevantes
 
 | Variable | Descripción |

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,1 @@
+"""Paquete de la aplicación FastAPI para la nevera virtual."""

--- a/backend/app/crud.py
+++ b/backend/app/crud.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date
+from typing import Iterable, List, Sequence
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlmodel import Session
+
+from . import models, schemas
+
+
+def normalize_name(name: str) -> str:
+    return " ".join(name.strip().split())
+
+
+def get_or_create_product(
+    session: Session,
+    *,
+    name: str,
+    unit: str,
+    category: str | None = None,
+    reorder_threshold: float | None = None,
+) -> models.Product:
+    normalized_name = normalize_name(name)
+    product = session.exec(
+        select(models.Product).where(func.lower(models.Product.name) == normalized_name.lower())
+    ).first()
+    if product:
+        if product.unit != unit:
+            product.unit = unit
+        if category and product.category != category:
+            product.category = category
+        if reorder_threshold is not None and product.reorder_threshold != reorder_threshold:
+            product.reorder_threshold = reorder_threshold
+        session.add(product)
+        session.commit()
+        session.refresh(product)
+        return product
+
+    product = models.Product(
+        name=normalized_name,
+        unit=unit,
+        category=category,
+        reorder_threshold=reorder_threshold,
+    )
+    session.add(product)
+    session.commit()
+    session.refresh(product)
+    return product
+
+
+def create_inventory_items(
+    session: Session, entries: Iterable[schemas.InventoryItemCreate]
+) -> List[models.InventoryItem]:
+    created: List[models.InventoryItem] = []
+    for entry in entries:
+        product = get_or_create_product(session, name=entry.product_name, unit=entry.unit)
+        item = models.InventoryItem(
+            product_id=product.id,
+            quantity=entry.quantity,
+            expires_at=entry.expires_at,
+            notes=entry.notes,
+        )
+        session.add(item)
+        session.commit()
+        session.refresh(item)
+        created.append(item)
+    return created
+
+
+def update_inventory_item(
+    session: Session, item_id: UUID, payload: schemas.InventoryItemUpdate
+) -> models.InventoryItem:
+    item = session.get(models.InventoryItem, item_id)
+    if not item:
+        raise ValueError("Inventory item not found")
+    if payload.quantity is not None:
+        item.quantity = payload.quantity
+    if payload.expires_at is not None:
+        item.expires_at = payload.expires_at
+    if payload.notes is not None:
+        item.notes = payload.notes
+    session.add(item)
+    session.commit()
+    session.refresh(item)
+    return item
+
+
+def delete_inventory_item(session: Session, item_id: UUID) -> None:
+    item = session.get(models.InventoryItem, item_id)
+    if item:
+        session.delete(item)
+        session.commit()
+
+
+def get_inventory_summary(session: Session) -> List[schemas.InventoryProductSummary]:
+    products = session.exec(select(models.Product)).all()
+    products.sort(key=lambda product: product.name.lower())
+    items = session.exec(select(models.InventoryItem)).all()
+
+    items_by_product: dict[UUID, List[models.InventoryItem]] = defaultdict(list)
+    for item in items:
+        items_by_product[item.product_id].append(item)
+
+    summaries: List[schemas.InventoryProductSummary] = []
+    for product in products:
+        product_items = items_by_product.get(product.id, [])
+        product_items.sort(key=lambda item: (item.expires_at or date.max, item.quantity))
+        total_quantity = sum(item.quantity for item in product_items)
+        summaries.append(
+            schemas.InventoryProductSummary(
+                product_id=product.id,
+                product_name=product.name,
+                unit=product.unit,
+                total_quantity=total_quantity,
+                reorder_threshold=product.reorder_threshold,
+                items=[
+                    schemas.InventoryItemRead(
+                        id=item.id,
+                        product_id=item.product_id,
+                        product_name=product.name,
+                        quantity=item.quantity,
+                        unit=product.unit,
+                        expires_at=item.expires_at,
+                        notes=item.notes,
+                    )
+                    for item in product_items
+                ],
+            )
+        )
+    return summaries
+
+
+def seed_demo_content(session: Session) -> None:
+    if session.exec(select(models.Product)).first():
+        return
+
+    milk = models.Product(name="Leche entera", unit="l", category="Lácteos")
+    eggs = models.Product(name="Huevos", unit="unidad", category="Huevos", reorder_threshold=6)
+    tomato = models.Product(name="Tomate", unit="kg", category="Verduras")
+    pasta = models.Product(name="Pasta", unit="kg", category="Granos")
+    cheese = models.Product(name="Queso parmesano", unit="kg", category="Lácteos")
+
+    session.add_all([milk, eggs, tomato, pasta, cheese])
+    session.commit()
+
+    session.add_all(
+        [
+            models.InventoryItem(product_id=milk.id, quantity=3.0),
+            models.InventoryItem(product_id=eggs.id, quantity=12),
+            models.InventoryItem(product_id=tomato.id, quantity=1.5),
+            models.InventoryItem(product_id=pasta.id, quantity=1.0),
+            models.InventoryItem(product_id=cheese.id, quantity=0.3),
+        ]
+    )
+    session.commit()
+
+    pasta_recipe = models.Recipe(
+        name="Pasta con tomate",
+        description="Receta sencilla de pasta con salsa de tomate",
+        servings=2,
+        instructions=(
+            "Cocer la pasta hasta que esté al dente. Sofreír tomate y mezclar con la pasta."
+        ),
+    )
+    omelette_recipe = models.Recipe(
+        name="Tortilla francesa",
+        description="Clásica tortilla de huevo",
+        servings=1,
+        instructions="Batir huevos, cocinar en sartén antiadherente y doblar.",
+    )
+
+    session.add_all([pasta_recipe, omelette_recipe])
+    session.commit()
+
+    session.add_all(
+        [
+            models.RecipeIngredient(
+                recipe_id=pasta_recipe.id,
+                product_id=pasta.id,
+                quantity_required=0.25,
+            ),
+            models.RecipeIngredient(
+                recipe_id=pasta_recipe.id,
+                product_id=tomato.id,
+                quantity_required=0.4,
+            ),
+            models.RecipeIngredient(
+                recipe_id=pasta_recipe.id,
+                product_id=cheese.id,
+                quantity_required=0.05,
+            ),
+            models.RecipeIngredient(
+                recipe_id=omelette_recipe.id,
+                product_id=eggs.id,
+                quantity_required=2,
+            ),
+            models.RecipeIngredient(
+                recipe_id=omelette_recipe.id,
+                product_id=milk.id,
+                quantity_required=0.1,
+            ),
+        ]
+    )
+    session.commit()
+
+
+def get_recipe_availability(session: Session) -> List[schemas.RecipeRead]:
+    products: Sequence[models.Product] = session.exec(select(models.Product)).all()
+    product_map = {product.id: product for product in products}
+
+    inventory_totals = {
+        product_id: total
+        for product_id, total in session.exec(
+            select(models.InventoryItem.product_id, func.sum(models.InventoryItem.quantity)).group_by(
+                models.InventoryItem.product_id
+            )
+        ).all()
+    }
+
+    recipes: Sequence[models.Recipe] = session.exec(select(models.Recipe)).all()
+    ingredients_by_recipe: dict[UUID, List[models.RecipeIngredient]] = defaultdict(list)
+    for ingredient in session.exec(select(models.RecipeIngredient)).all():
+        ingredients_by_recipe[ingredient.recipe_id].append(ingredient)
+
+    availability: List[schemas.RecipeRead] = []
+    for recipe in recipes:
+        missing: List[schemas.MissingIngredient] = []
+        for ingredient in ingredients_by_recipe.get(recipe.id, []):
+            product = product_map.get(ingredient.product_id)
+            if not product:
+                continue
+            available_quantity = inventory_totals.get(ingredient.product_id, 0) or 0
+            if available_quantity + 1e-6 < ingredient.quantity_required:
+                missing.append(
+                    schemas.MissingIngredient(
+                        product_name=product.name,
+                        required_quantity=ingredient.quantity_required,
+                        available_quantity=available_quantity,
+                        unit=product.unit,
+                    )
+                )
+        availability.append(
+            schemas.RecipeRead(
+                id=recipe.id,
+                name=recipe.name,
+                description=recipe.description,
+                servings=recipe.servings,
+                instructions=recipe.instructions,
+                can_make=len(missing) == 0,
+                missing_ingredients=missing,
+            )
+        )
+    return availability

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+
+from sqlmodel import Session, SQLModel, create_engine
+
+
+DATABASE_URL = os.getenv("INVENTORY_DATABASE_URL", "sqlite:///./inventory.db")
+
+engine = create_engine(
+    DATABASE_URL,
+    echo=False,
+    connect_args={"check_same_thread": False} if DATABASE_URL.startswith("sqlite") else {},
+)
+
+
+def create_db_and_tables() -> None:
+    """Ensure that the database schema exists."""
+
+    SQLModel.metadata.create_all(engine)
+
+
+@contextmanager
+def session_scope():
+    session = Session(engine)
+    try:
+        yield session
+    finally:
+        session.close()
+
+
+def get_session():
+    with Session(engine) as session:
+        yield session

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, FastAPI, File, HTTPException, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from sqlmodel import Session
+
+from . import crud, database, models, ocr, parsers, schemas
+
+app = FastAPI(title="Nevera Virtual API", docs_url="/api/docs", openapi_url="/api/openapi.json")
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=False,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+api_router = APIRouter(prefix="/api")
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    database.create_db_and_tables()
+    with database.session_scope() as session:
+        crud.seed_demo_content(session)
+
+
+@api_router.get("/inventory", response_model=list[schemas.InventoryProductSummary])
+def list_inventory(session: Session = Depends(database.get_session)):
+    return crud.get_inventory_summary(session)
+
+
+@api_router.post("/inventory/items", response_model=list[schemas.InventoryItemRead])
+def create_inventory_items(
+    payload: list[schemas.InventoryItemCreate], session: Session = Depends(database.get_session)
+):
+    created = crud.create_inventory_items(session, payload)
+    product_cache: dict = {}
+    response: list[schemas.InventoryItemRead] = []
+    for item in created:
+        product = product_cache.get(item.product_id)
+        if product is None:
+            product = session.get(models.Product, item.product_id)
+            product_cache[item.product_id] = product
+        product_name = product.name if product else ""
+        unit = product.unit if product else "unidad"
+        response.append(
+            schemas.InventoryItemRead(
+                id=item.id,
+                product_id=item.product_id,
+                product_name=product_name,
+                quantity=item.quantity,
+                unit=unit,
+                expires_at=item.expires_at,
+                notes=item.notes,
+            )
+        )
+    return response
+
+
+@api_router.patch("/inventory/items/{item_id}", response_model=schemas.InventoryItemRead)
+def update_inventory_item(
+    item_id: str, payload: schemas.InventoryItemUpdate, session: Session = Depends(database.get_session)
+):
+    try:
+        item_uuid = UUID(item_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Identificador de inventario inválido") from exc
+    try:
+        item = crud.update_inventory_item(session, item_id=item_uuid, payload=payload)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    product = session.get(models.Product, item.product_id)
+    product_name = product.name if product else ""
+    unit = product.unit if product else "unidad"
+    return schemas.InventoryItemRead(
+        id=item.id,
+        product_id=item.product_id,
+        product_name=product_name,
+        quantity=item.quantity,
+        unit=unit,
+        expires_at=item.expires_at,
+        notes=item.notes,
+    )
+
+
+@api_router.post("/inventory/receipt/parse-text", response_model=schemas.ReceiptParseResponse)
+def parse_receipt_text(request: dict[str, str]):
+    text = request.get("text", "")
+    return parsers.parse_receipt_text(text)
+
+
+@api_router.post("/inventory/receipt/scan", response_model=schemas.ReceiptParseResponse)
+async def scan_receipt(file: UploadFile = File(...)):
+    text, warnings = await ocr.extract_text_from_upload(file)
+    parsed = parsers.parse_receipt_text(text)
+    parsed.warnings.extend(warnings)
+    return parsed
+
+
+@api_router.post("/inventory/receipt/commit", response_model=list[schemas.InventoryItemRead])
+def commit_receipt_items(
+    payload: schemas.ReceiptCommitRequest, session: Session = Depends(database.get_session)
+):
+    entries = payload.items
+    created = crud.create_inventory_items(session, entries)
+    product_cache = {}
+    result = []
+    for item in created:
+        product = product_cache.get(item.product_id)
+        if product is None:
+            product = session.get(models.Product, item.product_id)
+            product_cache[item.product_id] = product
+        product_name = product.name if product else ""
+        unit = product.unit if product else "unidad"
+        result.append(
+            schemas.InventoryItemRead(
+                id=item.id,
+                product_id=item.product_id,
+                product_name=product_name,
+                quantity=item.quantity,
+                unit=unit,
+                expires_at=item.expires_at,
+                notes=item.notes,
+            )
+        )
+    return result
+
+
+@api_router.get("/recipes", response_model=list[schemas.RecipeRead])
+def list_recipes(session: Session = Depends(database.get_session)):
+    return crud.get_recipe_availability(session)
+
+
+app.include_router(api_router)

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Optional
+from uuid import UUID, uuid4
+
+from sqlmodel import Field, Relationship, SQLModel
+
+
+class Product(SQLModel, table=True):
+    __tablename__ = "products"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    name: str = Field(index=True)
+    category: Optional[str] = None
+    unit: str = Field(default="unidad")
+    reorder_threshold: Optional[float] = Field(default=None, nullable=True)
+
+    inventory_items: List["InventoryItem"] = Relationship(back_populates="product")
+    recipe_ingredients: List["RecipeIngredient"] = Relationship(back_populates="product")
+
+
+class InventoryItem(SQLModel, table=True):
+    __tablename__ = "inventory_items"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    product_id: UUID = Field(foreign_key="products.id", index=True)
+    quantity: float = Field(default=0)
+    storage_location: Optional[str] = Field(default=None, nullable=True)
+    batch_code: Optional[str] = Field(default=None, nullable=True)
+    expires_at: Optional[date] = Field(default=None, nullable=True)
+    notes: Optional[str] = Field(default=None, nullable=True)
+
+    product: Optional[Product] = Relationship(back_populates="inventory_items")
+
+
+class Recipe(SQLModel, table=True):
+    __tablename__ = "recipes"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    name: str = Field(index=True)
+    description: Optional[str] = None
+    servings: int = Field(default=2)
+    instructions: Optional[str] = None
+
+    ingredients: List["RecipeIngredient"] = Relationship(back_populates="recipe")
+
+
+class RecipeIngredient(SQLModel, table=True):
+    __tablename__ = "recipe_ingredients"
+
+    id: UUID = Field(default_factory=uuid4, primary_key=True, index=True)
+    recipe_id: UUID = Field(foreign_key="recipes.id", index=True)
+    product_id: UUID = Field(foreign_key="products.id", index=True)
+    quantity_required: float = Field(default=0)
+
+    recipe: Optional[Recipe] = Relationship(back_populates="ingredients")
+    product: Optional[Product] = Relationship(back_populates="recipe_ingredients")

--- a/backend/app/ocr.py
+++ b/backend/app/ocr.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import io
+from typing import List, Tuple
+
+from fastapi import HTTPException, UploadFile
+from PIL import Image
+
+try:
+    import pytesseract
+    from pytesseract import TesseractNotFoundError
+except ImportError:  # pragma: no cover - handled gracefully at runtime
+    pytesseract = None  # type: ignore
+    TesseractNotFoundError = RuntimeError  # type: ignore
+
+
+def extract_text_from_bytes(data: bytes) -> Tuple[str, List[str]]:
+    warnings: List[str] = []
+    try:
+        image = Image.open(io.BytesIO(data))
+    except Exception as exc:  # pragma: no cover - protective branch
+        raise HTTPException(status_code=400, detail=f"No se pudo leer la imagen: {exc}") from exc
+
+    if pytesseract is None:
+        warnings.append(
+            "pytesseract no está instalado. Instala el paquete y el binario 'tesseract-ocr' para habilitar el escaneo."
+        )
+        return "", warnings
+
+    try:
+        text = pytesseract.image_to_string(image)
+    except TesseractNotFoundError as exc:  # pragma: no cover - depende del entorno
+        warnings.append(
+            "No se encontró el ejecutable de Tesseract en el sistema. Instala 'tesseract-ocr' y configura la variable"
+            " TESSERACT_CMD si es necesario."
+        )
+        text = ""
+    return text, warnings
+
+
+async def extract_text_from_upload(file: UploadFile) -> Tuple[str, List[str]]:
+    data = await file.read()
+    if not data:
+        raise HTTPException(status_code=400, detail="El archivo recibido está vacío")
+    return extract_text_from_bytes(data)

--- a/backend/app/parsers.py
+++ b/backend/app/parsers.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Iterable, List
+
+try:  # pragma: no cover - fallback para entornos sin dependencias instaladas
+    from . import schemas  # type: ignore
+except Exception:  # pragma: no cover - ejecutado en entorno de pruebas sin pydantic
+    schemas = None  # type: ignore
+
+
+CURRENCY_PATTERN = re.compile(r"^[€$]?\d+[\.,]?\d*[€$]?$")
+QUANTITY_UNIT_PATTERN = re.compile(
+    r"(?P<quantity>\d+[\.,]?\d*)\s*(?P<unit>kg|g|l|ml|unidad(?:es)?|uds?|u|pack|pz|pcs)?",
+    flags=re.IGNORECASE,
+)
+MULTIPLIER_PATTERN = re.compile(r"(?P<count>\d+)[xX](?P<quantity>\d+[\.,]?\d*)(?P<unit>[a-zA-Z]+)?")
+TRAILING_MULTIPLIER_PATTERN = re.compile(r"^[xX](?P<count>\d+)$")
+
+
+@dataclass
+class ParsedLine:
+    name: str
+    quantity: float
+    unit: str
+
+
+@dataclass
+class ReceiptItemPayload:
+    product_name: str
+    quantity: float
+    unit: str
+    confidence: float | None = None
+
+
+@dataclass
+class ReceiptParsePayload:
+    raw_text: str
+    items: List[ReceiptItemPayload]
+    warnings: List[str]
+
+
+@dataclass
+class InventoryItemCreatePayload:
+    product_name: str
+    quantity: float
+    unit: str
+    expires_at: None = None
+    notes: None = None
+
+
+UNIT_NORMALIZATION = {
+    "uds": "unidad",
+    "ud": "unidad",
+    "u": "unidad",
+    "unidad": "unidad",
+    "unidades": "unidad",
+    "pz": "unidad",
+    "pcs": "unidad",
+    "pack": "unidad",
+    "kg": "kg",
+    "g": "g",
+    "l": "l",
+    "ml": "ml",
+}
+
+
+def _clean_line(line: str) -> str:
+    return line.strip()
+
+
+def _remove_price_tokens(tokens: List[str]) -> List[str]:
+    cleaned = list(tokens)
+    while cleaned and CURRENCY_PATTERN.match(cleaned[-1]):
+        cleaned.pop()
+    return cleaned
+
+
+def _normalize_unit(unit: str | None) -> str:
+    if not unit:
+        return "unidad"
+    return UNIT_NORMALIZATION.get(unit.lower(), unit.lower())
+
+
+def _parse_multiplier(tokens: List[str]) -> tuple[float | None, str | None]:
+    joined = "".join(tokens)
+    match = MULTIPLIER_PATTERN.search(joined)
+    if match:
+        count = float(match.group("count"))
+        quantity = float(match.group("quantity").replace(",", "."))
+        unit = match.group("unit")
+        total_quantity = count * quantity
+        return total_quantity, unit
+
+    for index, token in enumerate(tokens):
+        trailing = TRAILING_MULTIPLIER_PATTERN.match(token)
+        if trailing and index > 0:
+            prev_segment = tokens[index - 1]
+            prev_match = QUANTITY_UNIT_PATTERN.search(prev_segment)
+            if prev_match:
+                base_quantity = float(prev_match.group("quantity").replace(",", "."))
+                unit = prev_match.group("unit")
+                total_quantity = base_quantity * float(trailing.group("count"))
+                return total_quantity, unit
+    return None, None
+
+
+def parse_line(line: str) -> ParsedLine | None:
+    cleaned_line = _clean_line(line)
+    if not cleaned_line:
+        return None
+
+    tokens = _remove_price_tokens(cleaned_line.split())
+    if not tokens:
+        return None
+
+    multiplier_quantity, multiplier_unit = _parse_multiplier(tokens)
+
+    quantity = None
+    unit = None
+    match = None
+    for match in reversed(list(QUANTITY_UNIT_PATTERN.finditer(" ".join(tokens)))):
+        quantity = float(match.group("quantity").replace(",", "."))
+        unit = match.group("unit")
+        break
+
+    if quantity is None:
+        quantity = 1.0
+    if unit is None and multiplier_unit:
+        unit = multiplier_unit
+    normalized_unit = _normalize_unit(unit)
+
+    name_tokens: List[str]
+    if match:
+        name_tokens = " ".join(tokens)[: match.start()].split()
+    else:
+        name_tokens = tokens
+
+    name = " ".join(name_tokens).strip()
+    if not name:
+        name = "Artículo"
+
+    if multiplier_quantity is not None:
+        quantity = multiplier_quantity
+        if multiplier_unit:
+            normalized_unit = _normalize_unit(multiplier_unit)
+
+    return ParsedLine(name=name, quantity=quantity, unit=normalized_unit)
+
+
+def parse_receipt_text(text: str) -> schemas.ReceiptParseResponse:
+    raw_items: List[ReceiptItemPayload] = []
+    warnings: List[str] = []
+
+    if not text.strip():
+        warnings.append("El ticket está vacío o no se pudo extraer texto.")
+        if schemas:
+            return schemas.ReceiptParseResponse(raw_text=text, items=[], warnings=warnings)
+        return ReceiptParsePayload(raw_text=text, items=[], warnings=warnings)
+
+    for raw_line in text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.lower().startswith(("total", "subtotal", "iva")):
+            continue
+        parsed = parse_line(line)
+        if not parsed:
+            warnings.append(f"No se pudo interpretar la línea: '{line}'")
+            continue
+        raw_items.append(
+            ReceiptItemPayload(
+                product_name=parsed.name,
+                quantity=parsed.quantity,
+                unit=parsed.unit,
+            )
+        )
+
+    if not raw_items:
+        warnings.append("No se encontraron artículos en el ticket.")
+
+    if schemas:
+        schema_items = [
+            schemas.ReceiptItem(
+                product_name=item.product_name,
+                quantity=item.quantity,
+                unit=item.unit,
+            )
+            for item in raw_items
+        ]
+        return schemas.ReceiptParseResponse(raw_text=text, items=schema_items, warnings=warnings)
+
+    return ReceiptParsePayload(raw_text=text, items=raw_items, warnings=warnings)
+
+
+def transform_receipt_items_to_inventory(
+    items: Iterable[schemas.ReceiptItem],
+) -> List[schemas.InventoryItemCreate]:
+    inventory_entries = []
+    for item in items:
+        payload = {
+            "product_name": getattr(item, "product_name"),
+            "quantity": getattr(item, "quantity"),
+            "unit": getattr(item, "unit"),
+        }
+        if schemas:
+            entry = schemas.InventoryItemCreate(**payload)
+        else:  # pragma: no cover - usado en entorno de pruebas sin dependencias
+            entry = InventoryItemCreatePayload(**payload)  # type: ignore[assignment]
+        inventory_entries.append(entry)  # type: ignore[arg-type]
+    return inventory_entries

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field, validator
+
+
+class InventoryItemBase(BaseModel):
+    product_name: str = Field(..., description="Nombre del producto")
+    quantity: float = Field(..., gt=0, description="Cantidad del producto a registrar")
+    unit: str = Field(default="unidad", description="Unidad de medida (kg, l, unidad, etc.)")
+    expires_at: Optional[date] = Field(default=None)
+    notes: Optional[str] = None
+
+    @validator("unit")
+    def normalize_unit(cls, value: str) -> str:
+        normalized = value.strip().lower()
+        if normalized in {"uds", "ud", "unidad", "unidades", "u"}:
+            return "unidad"
+        if normalized in {"kg", "kilogramo", "kilogramos"}:
+            return "kg"
+        if normalized in {"g", "gramo", "gramos"}:
+            return "g"
+        if normalized in {"l", "litro", "litros"}:
+            return "l"
+        if normalized in {"ml", "mililitro", "mililitros"}:
+            return "ml"
+        return normalized
+
+
+class InventoryItemCreate(InventoryItemBase):
+    pass
+
+
+class InventoryItemUpdate(BaseModel):
+    quantity: Optional[float] = Field(default=None, gt=0)
+    expires_at: Optional[date] = None
+    notes: Optional[str] = None
+
+
+class InventoryItemRead(BaseModel):
+    id: UUID
+    product_id: UUID
+    product_name: str
+    quantity: float
+    unit: str
+    expires_at: Optional[date]
+    notes: Optional[str]
+
+
+class InventoryProductSummary(BaseModel):
+    product_id: UUID
+    product_name: str
+    unit: str
+    total_quantity: float
+    reorder_threshold: Optional[float]
+    items: List[InventoryItemRead]
+
+
+class ReceiptItem(BaseModel):
+    product_name: str
+    quantity: float
+    unit: str
+    confidence: Optional[float] = None
+
+
+class ReceiptParseResponse(BaseModel):
+    raw_text: str
+    items: List[ReceiptItem]
+    warnings: List[str] = Field(default_factory=list)
+
+
+class ReceiptCommitRequest(BaseModel):
+    items: List[InventoryItemCreate]
+
+
+class MissingIngredient(BaseModel):
+    product_name: str
+    required_quantity: float
+    available_quantity: float
+    unit: str
+
+
+class RecipeRead(BaseModel):
+    id: UUID
+    name: str
+    description: Optional[str]
+    servings: int
+    instructions: Optional[str]
+    can_make: bool
+    missing_ingredients: List[MissingIngredient]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.110.0
+uvicorn[standard]==0.27.1
+sqlmodel==0.0.14
+sqlalchemy==2.0.25
+pydantic==1.10.14
+python-multipart==0.0.7
+pillow==10.2.0
+pytesseract==0.3.10

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/tests/test_parsers.py
+++ b/backend/tests/test_parsers.py
@@ -1,0 +1,41 @@
+from app import parsers
+
+
+def test_parse_receipt_text_with_basic_lines():
+    raw = """
+    LECHE ENTERA 1L x2 2,40€
+    TOMATE ENSALADA 0,75kg 1,80€
+    HUEVOS CAMPEROS 12ud 3,20€
+    TOTAL 7,40€
+    """
+    result = parsers.parse_receipt_text(raw)
+    assert len(result.items) == 3
+
+    milk = result.items[0]
+    assert milk.product_name.lower().startswith("leche")
+    assert milk.quantity == 2.0
+    assert milk.unit == "l"
+
+    tomato = result.items[1]
+    assert tomato.quantity == 0.75
+    assert tomato.unit == "kg"
+
+    eggs = result.items[2]
+    assert eggs.quantity == 12
+    assert eggs.unit == "unidad"
+
+
+def test_parse_receipt_text_handles_empty_lines():
+    result = parsers.parse_receipt_text("\n\n")
+    assert result.items == []
+    assert any("vacío" in warning for warning in result.warnings)
+
+
+def test_transform_receipt_items_to_inventory():
+    parsed = parsers.parse_receipt_text("Pan integral 1 ud 1,20€")
+    entries = parsers.transform_receipt_items_to_inventory(parsed.items)
+    assert len(entries) == 1
+    entry = entries[0]
+    assert entry.product_name == "Pan integral"
+    assert entry.quantity == 1
+    assert entry.unit == "unidad"


### PR DESCRIPTION
## Summary
- build a FastAPI backend to manage the virtual fridge inventory, ingest receipt scans, and expose recipe availability
- add a static UI for listing and editing stock, manual entries, and uploading tickets by text or OCR image
- implement heuristic receipt parsing helpers with tests and graceful fallbacks when OCR dependencies are missing

## Testing
- pytest backend/tests


------
https://chatgpt.com/codex/tasks/task_e_6905eae0bbf083248dc23453dcc2d7bd