### PR TITLE
Add NutriApp tabbed dashboard prototype

### DIFF
--- a/Desarrollo web/nutriapp/.eslintrc.json
+++ b/Desarrollo web/nutriapp/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals", "next/typescript"]
+}

--- a/Desarrollo web/nutriapp/app/(tabs)/dashboard/page.tsx
+++ b/Desarrollo web/nutriapp/app/(tabs)/dashboard/page.tsx
@@ -1,0 +1,93 @@
+import { FiActivity, FiSun, FiTrendingUp } from "react-icons/fi";
+import QuickLogActions from "@/components/QuickLogActions";
+
+const hydrationLevels = [
+  { label: "Agua", value: "1.8 L", trend: "+0.3 L" },
+  { label: "Sueño", value: "7 h 45 min", trend: "Objetivo logrado" },
+  { label: "Pasos", value: "8.530", trend: "+1.200 vs ayer" }
+];
+
+const todayTimeline = [
+  {
+    title: "Desayuno energizante",
+    description: "Avena con frutos rojos y semillas",
+    time: "08:15",
+    icon: <FiSun aria-hidden="true" />
+  },
+  {
+    title: "Sesión HIIT",
+    description: "30 minutos, intensidad alta",
+    time: "12:40",
+    icon: <FiActivity aria-hidden="true" />
+  },
+  {
+    title: "Almuerzo equilibrado",
+    description: "Quinoa, salmón y vegetales asados",
+    time: "14:10",
+    icon: <FiTrendingUp aria-hidden="true" />
+  }
+];
+
+export default function DashboardPage() {
+  return (
+    <>
+      <header className="page-header">
+        <h1>Tu día en equilibrio</h1>
+        <p>
+          Visualiza métricas clave, registra hábitos y mantén el control de tu alimentación en una sola vista.
+        </p>
+      </header>
+      <QuickLogActions />
+      <section className="surface-card">
+        <h2>Métricas destacadas</h2>
+        <p className="surface-card__subtitle">
+          Seguimiento en tiempo real de tus indicadores diarios comparados con la tendencia semanal.
+        </p>
+        <div className="metrics-grid" role="list">
+          {hydrationLevels.map((metric) => (
+            <article key={metric.label} className="metric-chip" role="listitem">
+              <span>{metric.label}</span>
+              <strong>{metric.value}</strong>
+              <span>{metric.trend}</span>
+            </article>
+          ))}
+        </div>
+      </section>
+      <section className="card-grid" aria-label="Resumen de hábitos">
+        <article className="surface-card">
+          <div className="badge">Macro objetivos</div>
+          <h3>Balance nutricional</h3>
+          <p className="surface-card__subtitle">
+            Proteínas y carbohidratos dentro de lo previsto. Ajusta las grasas en la cena para cerrar el objetivo.
+          </p>
+        </article>
+        <article className="surface-card">
+          <div className="badge">Bienestar</div>
+          <h3>Estado de hidratación</h3>
+          <p className="surface-card__subtitle">
+            Te faltan 700 ml para alcanzar tu meta diaria. Programa un recordatorio en la tarde.
+          </p>
+        </article>
+      </section>
+      <section className="surface-card">
+        <h2>Agenda de hoy</h2>
+        <p className="surface-card__subtitle">
+          Revisa lo que ya completaste y lo que está por venir. Añadiremos nuevos eventos cuando registres actividades.
+        </p>
+        <div className="timeline" role="list">
+          {todayTimeline.map((item) => (
+            <article key={item.title} className="timeline-item" role="listitem">
+              <div>
+                <div className="timeline-item__title">{item.title}</div>
+                <div className="timeline-item__subtitle">{item.description}</div>
+              </div>
+              <div className="timeline-item__subtitle" aria-label={`Hora ${item.time}`}>
+                {item.icon} {item.time}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/Desarrollo web/nutriapp/app/(tabs)/fridge/page.tsx
+++ b/Desarrollo web/nutriapp/app/(tabs)/fridge/page.tsx
@@ -1,0 +1,84 @@
+import { FiAlertTriangle, FiCheck, FiFridge, FiList } from "react-icons/fi";
+
+const expiringSoon = [
+  {
+    name: "Yogur griego",
+    expiresIn: "2 días",
+    suggestion: "Úsalo en un smoothie con frutos del bosque"
+  },
+  {
+    name: "Espinacas frescas",
+    expiresIn: "3 días",
+    suggestion: "Prepáralas salteadas con garbanzos y limón"
+  }
+];
+
+const restockList = [
+  { name: "Huevos camperos", status: "Bajo", detail: "Quedan 2 unidades" },
+  { name: "Tofu firme", status: "Medio", detail: "Planifica compra para el viernes" },
+  { name: "Arándanos", status: "Agotado", detail: "Ideal para desayunos de la semana" }
+];
+
+export default function FridgePage() {
+  return (
+    <>
+      <header className="page-header">
+        <h1>Nevera inteligente</h1>
+        <p>
+          Visualiza el estado de tus alimentos, recibe alertas de caducidad y obtén ideas de recetas para aprovecharlos.
+        </p>
+      </header>
+      <section className="surface-card surface-card--highlight">
+        <div className="badge">Visión rápida</div>
+        <h2>Nivel de reservas</h2>
+        <p className="surface-card__subtitle">
+          Tu nevera está al 68% de capacidad. Organiza las comidas de la semana y evita desperdicios.
+        </p>
+        <div className="list" role="list">
+          <div className="list-item" role="listitem">
+            <div className="list-item__icon">
+              <FiFridge aria-hidden="true" />
+            </div>
+            <div className="list-item__body">
+              <strong>Categorías equilibradas</strong>
+              <span className="surface-card__subtitle">
+                Verduras y proteínas listas para tres días. Los snacks saludables bajaron un 15% esta semana.
+              </span>
+            </div>
+          </div>
+        </div>
+      </section>
+      <section className="card-grid" aria-label="Sugerencias de consumo">
+        {expiringSoon.map((item) => (
+          <article key={item.name} className="surface-card">
+            <div className="badge">Caduca en {item.expiresIn}</div>
+            <h3>{item.name}</h3>
+            <p className="surface-card__subtitle">{item.suggestion}</p>
+          </article>
+        ))}
+      </section>
+      <section className="surface-card">
+        <h2>Lista de reposición</h2>
+        <p className="surface-card__subtitle">
+          Prioriza tus compras con base en el plan nutricional y las recetas recomendadas.
+        </p>
+        <ul className="list" role="list">
+          {restockList.map((item) => (
+            <li key={item.name} className="list-item" role="listitem">
+              <div className="list-item__icon" aria-hidden="true">
+                {item.status === "Agotado" ? <FiAlertTriangle /> : <FiList />}
+              </div>
+              <div className="list-item__body">
+                <strong>{item.name}</strong>
+                <span className="surface-card__subtitle">{item.detail}</span>
+              </div>
+              <span className="surface-card__subtitle" aria-label={`Estado ${item.status}`}>
+                <FiCheck aria-hidden="true" /> {item.status}
+              </span>
+            </li>
+          ))}
+        </ul>
+      </section>
+    </>
+  );
+}

--- a/Desarrollo web/nutriapp/app/(tabs)/layout.tsx
+++ b/Desarrollo web/nutriapp/app/(tabs)/layout.tsx
@@ -1,0 +1,14 @@
+import TabNavigation from "@/components/TabNavigation";
+
+export default function TabsLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <TabNavigation />
+      <main>{children}</main>
+    </>
+  );
+}

--- a/Desarrollo web/nutriapp/app/(tabs)/settings/page.tsx
+++ b/Desarrollo web/nutriapp/app/(tabs)/settings/page.tsx
@@ -1,0 +1,78 @@
+export default function SettingsPage() {
+  return (
+    <>
+      <header className="page-header">
+        <h1>Configuración</h1>
+        <p>Ajusta tus preferencias, recordatorios y la intensidad de las recomendaciones.</p>
+      </header>
+      <section className="surface-card surface-card--highlight">
+        <div className="badge">Perfil metabólico</div>
+        <h2>Objetivo actual</h2>
+        <p className="surface-card__subtitle">
+          Mantener peso y mejorar composición corporal. Actualiza tu peso objetivo para recalibrar calorías y macros.
+        </p>
+      </section>
+      <section className="surface-card" aria-labelledby="notificaciones-heading">
+        <h2 id="notificaciones-heading">Recordatorios inteligentes</h2>
+        <p className="surface-card__subtitle">
+          Controla las notificaciones que recibirás durante el día. Todo está optimizado para no interrumpir tus rutinas.
+        </p>
+        <fieldset className="switch-fieldset">
+          <div className="toggle-row">
+            <label htmlFor="toggleMeals">Recordar comidas</label>
+            <div>
+              <span>Notificaciones flexibles para tus horarios habituales.</span>
+            </div>
+            <div className="toggle">
+              <input id="toggleMeals" type="checkbox" defaultChecked />
+              <span className="toggle__track">
+                <span className="toggle__indicator" aria-hidden="true" />
+              </span>
+            </div>
+          </div>
+          <div className="toggle-row">
+            <label htmlFor="toggleHydration">Seguimiento de hidratación</label>
+            <div>
+              <span>Alertas suaves si detectamos una ingesta baja.</span>
+            </div>
+            <div className="toggle">
+              <input id="toggleHydration" type="checkbox" defaultChecked />
+              <span className="toggle__track">
+                <span className="toggle__indicator" aria-hidden="true" />
+              </span>
+            </div>
+          </div>
+          <div className="toggle-row">
+            <label htmlFor="toggleTraining">Recordatorios de entrenamiento</label>
+            <div>
+              <span>Recibe sugerencias basadas en tu carga semanal y recuperación.</span>
+            </div>
+            <div className="toggle">
+              <input id="toggleTraining" type="checkbox" />
+              <span className="toggle__track">
+                <span className="toggle__indicator" aria-hidden="true" />
+              </span>
+            </div>
+          </div>
+        </fieldset>
+      </section>
+      <section className="surface-card" aria-labelledby="preferencias-heading">
+        <h2 id="preferencias-heading">Preferencias de contenido</h2>
+        <p className="surface-card__subtitle">
+          Personaliza el tipo de recomendaciones que aparecerán en tus tips diarios y en la nevera.
+        </p>
+        <div className="actions-row">
+          <button type="button" className="button button--ghost">
+            Ajustar planes de comida
+          </button>
+          <button type="button" className="button button--ghost">
+            Actualizar alergias
+          </button>
+          <button type="button" className="button button--primary">
+            Guardar cambios
+          </button>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/Desarrollo web/nutriapp/app/(tabs)/stats/page.tsx
+++ b/Desarrollo web/nutriapp/app/(tabs)/stats/page.tsx
@@ -1,0 +1,101 @@
+import { FiActivity, FiBarChart2, FiPieChart, FiTrendingUp } from "react-icons/fi";
+
+const weeklyHighlights = [
+  {
+    title: "Consumo promedio",
+    value: "1.950 kcal",
+    detail: "-5% respecto a la semana pasada",
+    icon: <FiPieChart aria-hidden="true" />
+  },
+  {
+    title: "Entrenamientos completados",
+    value: "4 sesiones",
+    detail: "+1 respecto al objetivo semanal",
+    icon: <FiActivity aria-hidden="true" />
+  },
+  {
+    title: "Peso estable",
+    value: "62,4 kg",
+    detail: "Variación < 0.3 kg",
+    icon: <FiTrendingUp aria-hidden="true" />
+  }
+];
+
+const macronutrients = [
+  { label: "Proteínas", percentage: 32, hint: "Excelente" },
+  { label: "Carbohidratos", percentage: 45, hint: "En rango" },
+  { label: "Grasas saludables", percentage: 23, hint: "Añadir frutos secos" }
+];
+
+export default function StatsPage() {
+  return (
+    <>
+      <header className="page-header">
+        <h1>Estadísticas y tendencias</h1>
+        <p>
+          Analiza tu progreso con indicadores claros y recomendaciones accionables para seguir mejorando.
+        </p>
+      </header>
+      <section className="card-grid" aria-label="Datos destacados de la semana">
+        {weeklyHighlights.map((item) => (
+          <article key={item.title} className="surface-card">
+            <div className="badge">Semana actual</div>
+            <h3>{item.title}</h3>
+            <div className="list-item" aria-hidden="true">
+              <div className="list-item__icon">{item.icon}</div>
+              <div className="list-item__body">
+                <strong>{item.value}</strong>
+                <span className="surface-card__subtitle">{item.detail}</span>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+      <section className="surface-card">
+        <h2>Distribución de macronutrientes</h2>
+        <p className="surface-card__subtitle">
+          Controla el equilibrio de tus macros. Ajustamos los objetivos según tu plan de entrenamiento activo.
+        </p>
+        <div className="list" role="list">
+          {macronutrients.map((macro) => (
+            <div key={macro.label} className="list-item" role="listitem">
+              <div className="list-item__icon" aria-hidden="true">
+                <FiBarChart2 />
+              </div>
+              <div className="list-item__body">
+                <strong>{macro.label}</strong>
+                <span className="surface-card__subtitle">{macro.hint}</span>
+                <div
+                  role="progressbar"
+                  aria-valuenow={macro.percentage}
+                  aria-valuemin={0}
+                  aria-valuemax={100}
+                  aria-label={`Progreso de ${macro.label}`}
+                  style={{
+                    width: "100%",
+                    height: "10px",
+                    borderRadius: "999px",
+                    background: "rgba(148, 163, 184, 0.2)",
+                    overflow: "hidden"
+                  }}
+                >
+                  <span
+                    style={{
+                      display: "block",
+                      width: `${macro.percentage}%`,
+                      height: "100%",
+                      background: "linear-gradient(160deg, rgba(56, 189, 248, 0.9), rgba(168, 85, 247, 0.8))"
+                    }}
+                  />
+                </div>
+              </div>
+              <span className="surface-card__subtitle" aria-hidden="true">
+                {macro.percentage}%
+              </span>
+            </div>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/Desarrollo web/nutriapp/app/(tabs)/tips/page.tsx
+++ b/Desarrollo web/nutriapp/app/(tabs)/tips/page.tsx
@@ -1,0 +1,83 @@
+import { FiHeart, FiSun, FiTarget } from "react-icons/fi";
+
+const wellnessTips = [
+  {
+    title: "Ritual matutino",
+    description:
+      "Comienza con 10 minutos de movilidad y agua tibia con limón para activar tu metabolismo.",
+    icon: <FiSun aria-hidden="true" />
+  },
+  {
+    title: "Micro decisiones",
+    description:
+      "Prepara snacks ricos en proteínas los domingos. Así reduces la tentación de opciones ultra procesadas.",
+    icon: <FiTarget aria-hidden="true" />
+  },
+  {
+    title: "Respira y conecta",
+    description:
+      "Haz pausas conscientes después de comer. Esto mejora la digestión y evita picos de estrés.",
+    icon: <FiHeart aria-hidden="true" />
+  }
+];
+
+export default function TipsPage() {
+  return (
+    <>
+      <header className="page-header">
+        <h1>Tips personalizados</h1>
+        <p>
+          Hábitos diseñados por tu coach digital según tus datos de actividad, preferencias y objetivos nutricionales.
+        </p>
+      </header>
+      <section className="surface-card surface-card--highlight">
+        <div className="badge">Recomendación del día</div>
+        <h2>Planifica tu cena</h2>
+        <p className="surface-card__subtitle">
+          Incluye verduras de hoja verde y una proteína ligera. Así llegarás a tus macros con una digestión ligera antes de dormir.
+        </p>
+      </section>
+      <section className="surface-card">
+        <h2>Hábitos sugeridos</h2>
+        <p className="surface-card__subtitle">
+          Incorpora estos hábitos en tu agenda. Puedes marcarlos como completados desde el dashboard cuando los practiques.
+        </p>
+        <ul className="list" role="list">
+          {wellnessTips.map((tip) => (
+            <li key={tip.title} className="list-item" role="listitem">
+              <div className="list-item__icon" aria-hidden="true">
+                {tip.icon}
+              </div>
+              <div className="list-item__body">
+                <strong>{tip.title}</strong>
+                <span className="surface-card__subtitle">{tip.description}</span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </section>
+      <section className="surface-card">
+        <h2>Lecturas recomendadas</h2>
+        <p className="surface-card__subtitle">
+          Profundiza con artículos seleccionados por especialistas en nutrición y bienestar.
+        </p>
+        <div className="card-grid" aria-label="Recursos">
+          <article className="surface-card">
+            <div className="badge">5 min</div>
+            <h3>El poder de las proteínas vegetales</h3>
+            <p className="surface-card__subtitle">
+              Descubre combinaciones sencillas para lograr perfiles completos de aminoácidos en tu dieta diaria.
+            </p>
+          </article>
+          <article className="surface-card">
+            <div className="badge">Audio</div>
+            <h3>Respiración para atletas urbanos</h3>
+            <p className="surface-card__subtitle">
+              Un podcast breve con ejercicios prácticos que puedes realizar entre reuniones.
+            </p>
+          </article>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/Desarrollo web/nutriapp/app/globals.css
+++ b/Desarrollo web/nutriapp/app/globals.css
@@ -1,0 +1,427 @@
+:root {
+  color-scheme: dark;
+  --color-background: #0f172a;
+  --color-surface: rgba(30, 41, 59, 0.75);
+  --color-surface-elevated: rgba(45, 55, 72, 0.7);
+  --color-outline: rgba(148, 163, 184, 0.35);
+  --color-primary: #38bdf8;
+  --color-accent: #a855f7;
+  --color-success: #34d399;
+  --color-warning: #facc15;
+  --color-text-primary: #f8fafc;
+  --color-text-secondary: rgba(226, 232, 240, 0.72);
+  --color-text-muted: rgba(148, 163, 184, 0.7);
+  --radius-lg: 20px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --shadow-lg: 0 32px 80px -48px rgba(15, 23, 42, 0.9);
+  --shadow-sm: 0 12px 32px -24px rgba(15, 23, 42, 0.7);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-inter), "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.12), transparent 40%),
+    radial-gradient(circle at top right, rgba(168, 85, 247, 0.14), transparent 45%),
+    linear-gradient(160deg, rgba(15, 23, 42, 0.9), rgba(15, 23, 42, 0.88));
+  color: var(--color-text-primary);
+  min-height: 100%;
+}
+
+body {
+  background-attachment: fixed;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus-visible,
+button:focus-visible,
+input:focus-visible {
+  outline: 3px solid rgba(56, 189, 248, 0.6);
+  outline-offset: 2px;
+}
+
+main {
+  width: min(1100px, 100% - 3rem);
+  margin: 0 auto;
+  padding: 2.5rem 0 3.5rem;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.tab-navigation {
+  display: flex;
+  gap: 0.75rem;
+  padding: 1.5rem 1.5rem 1rem;
+  width: min(1100px, 100% - 3rem);
+  margin: 0 auto;
+  background: rgba(15, 23, 42, 0.65);
+  backdrop-filter: blur(24px);
+  border: 1px solid rgba(148, 163, 184, 0.22);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  position: sticky;
+  top: 1.5rem;
+  z-index: 10;
+}
+
+.tab-navigation__link {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.75rem 0.5rem;
+  border-radius: var(--radius-md);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  transition: all 0.3s ease;
+  border: 1px solid transparent;
+}
+
+.tab-navigation__link svg {
+  width: 22px;
+  height: 22px;
+}
+
+.tab-navigation__link:hover {
+  color: var(--color-text-primary);
+  border-color: rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.08);
+}
+
+.tab-navigation__link[aria-current="page"] {
+  color: var(--color-text-primary);
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.2), rgba(168, 85, 247, 0.2));
+  border-color: rgba(56, 189, 248, 0.45);
+  box-shadow: var(--shadow-sm);
+}
+
+.page-header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  margin-bottom: 1.8rem;
+}
+
+.page-header h1 {
+  font-size: clamp(2.15rem, 2.4vw + 1.5rem, 3rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  margin: 0;
+}
+
+.page-header p {
+  margin: 0;
+  font-size: 1rem;
+  color: var(--color-text-secondary);
+}
+
+.surface-card {
+  background: linear-gradient(160deg, rgba(30, 41, 59, 0.9), rgba(17, 24, 39, 0.8));
+  border-radius: var(--radius-lg);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  padding: 1.5rem;
+  box-shadow: var(--shadow-sm);
+  display: flex;
+  flex-direction: column;
+  gap: 0.8rem;
+}
+
+.surface-card--highlight {
+  border: 1px solid rgba(56, 189, 248, 0.35);
+  background: linear-gradient(160deg, rgba(56, 189, 248, 0.25), rgba(15, 23, 42, 0.85));
+}
+
+.surface-card h2,
+.surface-card h3 {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+}
+
+.surface-card__subtitle {
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+}
+
+.metrics-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+}
+
+.metric-chip {
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  background: rgba(15, 23, 42, 0.55);
+}
+
+.metric-chip strong {
+  font-size: 1.45rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+
+.metric-chip span {
+  font-size: 0.85rem;
+  color: var(--color-text-muted);
+}
+
+.badge {
+  align-self: flex-start;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--color-primary);
+  border: 1px solid rgba(56, 189, 248, 0.35);
+}
+
+.actions-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.button {
+  border: none;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  padding: 0.85rem 1.3rem;
+  font-size: 0.95rem;
+}
+
+.button--primary {
+  background: linear-gradient(150deg, rgba(56, 189, 248, 0.9), rgba(14, 165, 233, 0.9));
+  color: #0f172a;
+}
+
+.button--primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 35px -20px rgba(56, 189, 248, 0.7);
+}
+
+.button--ghost {
+  background: transparent;
+  color: var(--color-text-primary);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+}
+
+.button--ghost:hover {
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.timeline-item {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 0.5rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.timeline-item__title {
+  font-weight: 600;
+}
+
+.timeline-item__subtitle {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.list-item {
+  display: flex;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.list-item__icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 14px;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--color-primary);
+}
+
+.list-item__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.switch-fieldset {
+  border: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.toggle-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.toggle-row label {
+  font-weight: 500;
+}
+
+.toggle-row span {
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  gap: 0.5rem;
+}
+
+.toggle input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.toggle__track {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 52px;
+  height: 28px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.35);
+  transition: background 0.2s ease;
+}
+
+.toggle__indicator {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  background: var(--color-text-primary);
+  transition: transform 0.25s ease;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.35);
+.toggle input:checked + .toggle__track {
+  background: rgba(56, 189, 248, 0.45);
+}
+
+.toggle input:checked + .toggle__track .toggle__indicator {
+  transform: translateX(24px);
+  background: var(--color-primary);
+}
+
+.feedback-banner {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1rem;
+  border-radius: var(--radius-md);
+  background: rgba(52, 211, 153, 0.16);
+  border: 1px solid rgba(52, 211, 153, 0.45);
+  color: var(--color-success);
+  font-weight: 600;
+}
+
+@media (max-width: 820px) {
+  .tab-navigation {
+    top: 1rem;
+    gap: 0.5rem;
+    padding: 1rem;
+  }
+
+  .tab-navigation__link {
+    font-size: 0.8rem;
+  }
+
+  main {
+    width: min(100%, 100% - 2rem);
+    padding: 2rem 0 3rem;
+  }
+}
+
+@media (max-width: 620px) {
+  .tab-navigation {
+    flex-wrap: wrap;
+    justify-content: center;
+  }
+
+  .tab-navigation__link {
+    flex: 1 1 calc(50% - 0.5rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/Desarrollo web/nutriapp/app/layout.tsx
+++ b/Desarrollo web/nutriapp/app/layout.tsx
@@ -1,0 +1,25 @@
+import type { Metadata } from "next";
+import "./globals.css";
+import { Inter } from "next/font/google";
+
+const inter = Inter({ subsets: ["latin"], variable: "--font-inter" });
+
+export const metadata: Metadata = {
+  title: "NutriApp Insights",
+  description: "Panel nutricional con navegación por pestañas y diseño accesible",
+  applicationName: "NutriApp Insights"
+};
+
+export default function RootLayout({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <html lang="es" className={inter.variable}>
+      <body>
+        <div className="app-shell">{children}</div>
+      </body>
+    </html>
+  );
+}

--- a/Desarrollo web/nutriapp/app/page.tsx
+++ b/Desarrollo web/nutriapp/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function IndexPage() {
+  redirect("/dashboard");
+}

--- a/Desarrollo web/nutriapp/components/QuickLogActions.tsx
+++ b/Desarrollo web/nutriapp/components/QuickLogActions.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { FiActivity, FiCheckCircle, FiClock, FiPlusCircle } from "react-icons/fi";
+
+type FeedbackType = "meal" | "training" | null;
+
+type ActionState = {
+  status: FeedbackType;
+  timestamp: number | null;
+};
+
+const FEEDBACK_DURATION = 3200;
+
+export default function QuickLogActions() {
+  const [{ status, timestamp }, setActionState] = useState<ActionState>({
+    status: null,
+    timestamp: null
+  });
+
+  const handleAction = (type: Exclude<FeedbackType, null>) => {
+    const nextTimestamp = Date.now();
+    setActionState({ status: type, timestamp: nextTimestamp });
+
+    window.setTimeout(() => {
+      setActionState((prev) =>
+        prev.timestamp === nextTimestamp ? { status: null, timestamp: null } : prev
+      );
+    }, FEEDBACK_DURATION);
+  };
+
+  const feedbackMessage = useMemo(() => {
+    if (status === "meal") {
+      return "¡Comida registrada! Tu dashboard ya refleja el cambio.";
+    }
+
+    if (status === "training") {
+      return "Entrenamiento añadido. Ajustamos tus objetivos en tiempo real.";
+    }
+
+    return null;
+  }, [status]);
+
+  return (
+    <div className="surface-card surface-card--highlight" aria-live="polite">
+      <div className="badge">Acciones rápidas</div>
+      <h2>Registrar actividad</h2>
+      <p className="surface-card__subtitle">
+        Añade comidas o entrenamientos y obtén feedback instantáneo para mantener tus hábitos al día.
+      </p>
+      <div className="actions-row" role="group" aria-label="Registrar comidas o entrenamientos">
+        <button
+          type="button"
+          className="button button--primary"
+          onClick={() => handleAction("meal")}
+        >
+          <FiPlusCircle aria-hidden="true" />
+          Registrar comida
+        </button>
+        <button
+          type="button"
+          className="button button--ghost"
+          onClick={() => handleAction("training")}
+        >
+          <FiActivity aria-hidden="true" />
+          Añadir entrenamiento
+        </button>
+      </div>
+      {status && feedbackMessage ? (
+        <div className="feedback-banner" role="status">
+          <FiCheckCircle aria-hidden="true" />
+          <span>{feedbackMessage}</span>
+          <span className="surface-card__subtitle" style={{ display: "inline-flex", gap: "0.35rem" }}>
+            <FiClock aria-hidden="true" /> hace un momento
+          </span>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/Desarrollo web/nutriapp/components/TabNavigation.tsx
+++ b/Desarrollo web/nutriapp/components/TabNavigation.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { FiBarChart2, FiFridge, FiHome, FiSettings, FiStar } from "react-icons/fi";
+
+const tabs = [
+  {
+    href: "/dashboard",
+    label: "Diario",
+    description: "Resumen diario",
+    icon: FiHome
+  },
+  {
+    href: "/fridge",
+    label: "Nevera",
+    description: "Inventario inteligente",
+    icon: FiFridge
+  },
+  {
+    href: "/stats",
+    label: "Estadísticas",
+    description: "Tendencias y métricas",
+    icon: FiBarChart2
+  },
+  {
+    href: "/tips",
+    label: "Tips",
+    description: "Recomendaciones personalizadas",
+    icon: FiStar
+  },
+  {
+    href: "/settings",
+    label: "Configuración",
+    description: "Preferencias de la app",
+    icon: FiSettings
+  }
+] as const;
+
+export default function TabNavigation() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="tab-navigation" aria-label="Secciones principales">
+      {tabs.map((tab) => {
+        const Icon = tab.icon;
+        const isActive = pathname === tab.href || pathname.startsWith(`${tab.href}/`);
+
+        return (
+          <Link
+            key={tab.href}
+            href={tab.href}
+            className="tab-navigation__link"
+            aria-current={isActive ? "page" : undefined}
+            aria-label={`${tab.label}. ${tab.description}`}
+          >
+            <Icon aria-hidden="true" focusable="false" />
+            <span>{tab.label}</span>
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/Desarrollo web/nutriapp/next-env.d.ts
+++ b/Desarrollo web/nutriapp/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/Desarrollo web/nutriapp/next.config.js
+++ b/Desarrollo web/nutriapp/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/Desarrollo web/nutriapp/package.json
+++ b/Desarrollo web/nutriapp/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "nutriapp",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "react-icons": "4.11.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.45",
+    "@types/react-dom": "18.2.18",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/Desarrollo web/nutriapp/tsconfig.json
+++ b/Desarrollo web/nutriapp/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{
+      "name": "next"
+    }],
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- create a Next.js app with tab navigation and shared layout for the nutrition experience
- prototype dashboard, fridge, stats, tips, and settings screens with consistent styling
- add interactive quick logging feedback for meals and entrenamientos

## Testing
- npm install *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fnode)*

------
https://chatgpt.com/codex/tasks/task_e_6905f3bb377c83249832561d39bede9e