### PR TITLE
Add FastAPI notification service with tests and deployment docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+
+      - name: Lint with Ruff
+        run: ruff check .
+
+      - name: Run tests
+        run: pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.venv/
+__pycache__/
+*.pyc
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Computing
 
-Este repositorio reúne distintos proyectos y ejercicios desarrollados para practicar tecnologías web, análisis de datos y machine learning. Además se incluyen los recursos necesarios para ejecutar una pila de ejemplo formada por un frontend estático, un backend en FastAPI y una base de datos PostgreSQL.
+Este repositorio reúne distintos proyectos y ejercicios desarrollados para practicar tecnologías web, análisis de datos y machine learning. Además se incluyen los recursos necesarios para ejecutar una pila de ejemplo formada por un frontend estático y un backend en FastAPI que expone la configuración de ventanas horarias para el envío de notificaciones.
 
 ## 📦 Instalación
 
@@ -15,55 +15,65 @@ Este repositorio reúne distintos proyectos y ejercicios desarrollados para prac
    ```
 
 3. **Configurar variables de entorno**
-   - Copia el archivo `.env.example` y renómbralo a `.env`.
-   - Ajusta las credenciales de base de datos y las ventanas horarias de notificaciones según tus necesidades.
-   ```bash
-   cp .env.example .env
-   ```
+   - Define las variables `NOTIFICATION_MORNING_WINDOW`, `NOTIFICATION_EVENING_WINDOW` y `NOTIFICATION_TIMEZONE` para personalizar el horario de notificaciones. Cada ventana debe utilizar el formato `HH:MM-HH:MM`.
 
 ## ▶️ Uso
 
-Con los requisitos previos instalados y el archivo `.env` configurado puedes levantar los servicios con Docker Compose:
+### Backend
+
+Con Python 3.11 instalado, crea un entorno virtual y ejecuta:
 
 ```bash
-docker compose up --build
+pip install -r requirements.txt
+uvicorn backend.app.main:app --reload
 ```
 
-Los servicios expuestos son:
+La API expondrá:
 
-| Servicio   | Puerto local | Descripción |
-|------------|--------------|-------------|
-| Frontend   | `http://localhost:8080` | Sitio estático contenido en `Desarrollo web/` servido con Nginx. |
-| Backend    | `http://localhost:8000` | API FastAPI con endpoints de salud y consulta de horarios de notificación. |
-| Base de datos | `localhost:5432` | Instancia PostgreSQL con volúmenes persistentes. |
+| Endpoint | Descripción |
+|----------|-------------|
+| `GET /health` | Devuelve `{ "status": "ok" }` para comprobar que el servicio está operativo. |
+| `GET /notifications/schedule` | Devuelve las ventanas horarias activas y la zona horaria configurada. |
 
-Para detener los servicios ejecuta:
+### Frontend
+
+El directorio `Desarrollo web/` contiene el sitio estático. Puedes servirlo con cualquier servidor de archivos estáticos. Un ejemplo rápido utilizando `python -m http.server`:
 
 ```bash
-docker compose down
+cd "Desarrollo web"
+python -m http.server 8080
 ```
 
 ### Variables de entorno relevantes
 
 | Variable | Descripción |
 |----------|-------------|
-| `POSTGRES_DB`, `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_HOST`, `POSTGRES_PORT` | Configuración de la base de datos PostgreSQL. |
 | `NOTIFICATION_MORNING_WINDOW`, `NOTIFICATION_EVENING_WINDOW` | Ventanas horarias (formato `HH:MM-HH:MM`) utilizadas por el backend para programar notificaciones. |
 | `NOTIFICATION_TIMEZONE` | Zona horaria que se empleará al interpretar las ventanas configuradas. |
 
 El backend expone el endpoint `GET /notifications/schedule` para consultar los valores actuales de estas variables.
 
-## 🚀 CI/CD
+## 🧪 Pruebas
 
-El flujo definido en `.github/workflows/deploy.yml` construye las imágenes, valida las variables de horario de notificación y compila el backend. Cuando se hace push a la rama `main`, el job de despliegue ejecuta `scripts/deploy.sh`, que automatiza la construcción y el arranque de los servicios con Docker Compose.
-
-Si deseas realizar un despliegue manual, ejecuta:
+El repositorio incluye tests unitarios y de extremo a extremo para el backend. Para ejecutarlos junto con el linting utiliza:
 
 ```bash
-./scripts/deploy.sh
+pip install -r requirements-dev.txt
+ruff check .
+pytest
 ```
 
-Asegúrate de tener un archivo `.env` válido antes de lanzar el script.
+El flujo de integración continua definido en `.github/workflows/ci.yml` ejecuta los mismos pasos en GitHub Actions.
+
+### Pruebas manuales
+
+Antes de publicar una versión revisa manualmente:
+
+1. Cargar el frontend en `http://localhost:8080` y navegar por las vistas principales (`index.html`, `home.html`, `eventos.html`) para verificar enlaces y recursos.
+2. Ejecutar el backend con `uvicorn` y consultar `GET /notifications/schedule` comprobando que refleja los valores de las variables de entorno configuradas.
+3. Modificar temporalmente la ventana de la tarde y repetir la petición para confirmar que el horario se actualiza correctamente.
+
+Consulta la guía completa de despliegue y hosting en `docs/DEPLOYMENT.md`.
 
 ## 🤝 Contribuir
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,0 +1,58 @@
+"""Configuración de la aplicación FastAPI."""
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from typing import Mapping, MutableMapping
+
+from pydantic import BaseModel, Field
+
+from .notifications import NotificationSchedule, build_schedule
+
+
+class Settings(BaseModel):
+    """Valores configurables mediante variables de entorno."""
+
+    morning_window: str = Field(default="08:00-12:00")
+    evening_window: str = Field(default="17:00-20:00")
+    timezone: str = Field(default="Europe/Madrid")
+
+    def schedule(self) -> NotificationSchedule:
+        return build_schedule(
+            timezone=self.timezone,
+            windows=(self.morning_window, self.evening_window),
+        )
+
+
+ENV_MAPPING: Mapping[str, str] = {
+    "morning_window": "NOTIFICATION_MORNING_WINDOW",
+    "evening_window": "NOTIFICATION_EVENING_WINDOW",
+    "timezone": "NOTIFICATION_TIMEZONE",
+}
+
+
+def load_settings(environ: MutableMapping[str, str] | None = None) -> Settings:
+    """Crea ``Settings`` a partir de un diccionario estilo ``os.environ``."""
+
+    environ = environ or os.environ
+    data: dict[str, str] = {}
+
+    for field_name, env_name in ENV_MAPPING.items():
+        value = environ.get(env_name)
+        if value:
+            data[field_name] = value
+
+    return Settings(**data)
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Devuelve la configuración cargada desde las variables de entorno."""
+
+    return load_settings()
+
+
+def get_schedule() -> NotificationSchedule:
+    """Acceso auxiliar para reutilizar la lógica en los endpoints."""
+
+    return get_settings().schedule()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,20 @@
+"""Entrypoint de la API FastAPI."""
+from fastapi import FastAPI, HTTPException
+
+from .config import get_schedule
+from .notifications import NotificationSchedule
+
+app = FastAPI(title="Notificaciones Sureuskadi", version="1.0.0")
+
+
+@app.get("/health")
+def health_check() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/notifications/schedule", response_model=NotificationSchedule)
+def read_schedule() -> NotificationSchedule:
+    try:
+        return get_schedule()
+    except ValueError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/notifications.py
+++ b/backend/app/notifications.py
@@ -1,0 +1,69 @@
+"""Notification scheduling logic for the FastAPI backend."""
+from __future__ import annotations
+
+from datetime import time
+from typing import Iterable
+
+from pydantic import BaseModel
+
+
+class NotificationWindow(BaseModel):
+    """Time window where notifications can be sent."""
+
+    start: time
+    end: time
+
+    model_config = {"frozen": True}
+
+
+class NotificationSchedule(BaseModel):
+    """Full schedule returned by the API."""
+
+    timezone: str
+    morning: NotificationWindow
+    evening: NotificationWindow
+
+    model_config = {"frozen": True}
+
+
+def _parse_time_component(component: str, *, field: str) -> time:
+    try:
+        hour_str, minute_str = component.split(":", maxsplit=1)
+    except ValueError as exc:  # pragma: no cover - defensive branch
+        raise ValueError(f"{field} debe tener el formato HH:MM") from exc
+
+    if not hour_str.isdigit() or not minute_str.isdigit():
+        raise ValueError(f"{field} debe contener valores numéricos")
+
+    hour = int(hour_str)
+    minute = int(minute_str)
+
+    if hour not in range(0, 24) or minute not in range(0, 60):
+        raise ValueError(f"{field} debe estar en un rango válido (00:00-23:59)")
+
+    return time(hour=hour, minute=minute)
+
+
+def parse_window(window: str) -> NotificationWindow:
+    """Parsea una ventana en formato ``HH:MM-HH:MM``."""
+
+    if "-" not in window:
+        raise ValueError("Las ventanas deben usar el formato HH:MM-HH:MM")
+
+    start_raw, end_raw = window.split("-", maxsplit=1)
+    start = _parse_time_component(start_raw.strip(), field="Inicio")
+    end = _parse_time_component(end_raw.strip(), field="Fin")
+
+    if start >= end:
+        raise ValueError("La hora de inicio debe ser menor que la hora de fin")
+
+    return NotificationWindow(start=start, end=end)
+
+
+def build_schedule(*, timezone: str, windows: Iterable[str]) -> NotificationSchedule:
+    morning_window, evening_window = list(windows)
+    return NotificationSchedule(
+        timezone=timezone,
+        morning=parse_window(morning_window),
+        evening=parse_window(evening_window),
+    )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,0 +1,28 @@
+from fastapi.testclient import TestClient
+
+from backend.app import config
+from backend.app.main import app
+
+
+def test_health_endpoint_returns_ok():
+    client = TestClient(app)
+    response = client.get("/health")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_notifications_schedule_endpoint(monkeypatch):
+    monkeypatch.setenv("NOTIFICATION_MORNING_WINDOW", "06:30-08:00")
+    monkeypatch.setenv("NOTIFICATION_EVENING_WINDOW", "18:30-20:00")
+    monkeypatch.setenv("NOTIFICATION_TIMEZONE", "Europe/Madrid")
+    config.get_settings.cache_clear()
+
+    client = TestClient(app)
+    response = client.get("/notifications/schedule")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "timezone": "Europe/Madrid",
+        "morning": {"start": "06:30:00", "end": "08:00:00"},
+        "evening": {"start": "18:30:00", "end": "20:00:00"},
+    }

--- a/backend/tests/test_notifications.py
+++ b/backend/tests/test_notifications.py
@@ -1,0 +1,59 @@
+from datetime import time
+
+import pytest
+
+from backend.app import config
+from backend.app.notifications import NotificationWindow, build_schedule, parse_window
+
+
+def test_parse_window_success():
+    window = parse_window("08:30-10:15")
+    assert window == NotificationWindow(start=time(8, 30), end=time(10, 15))
+
+
+def test_parse_window_invalid_format():
+    with pytest.raises(ValueError):
+        parse_window("0830-1015")
+
+
+def test_parse_window_start_after_end():
+    with pytest.raises(ValueError):
+        parse_window("18:00-08:00")
+
+
+def test_build_schedule_uses_timezone():
+    schedule = build_schedule(
+        timezone="Europe/Madrid",
+        windows=("08:00-09:00", "18:00-19:00"),
+    )
+
+    assert schedule.morning.start == time(8, 0)
+    assert schedule.evening.end == time(19, 0)
+    assert schedule.timezone == "Europe/Madrid"
+
+
+def test_load_settings_from_env(monkeypatch):
+    env = {
+        "NOTIFICATION_MORNING_WINDOW": "06:00-07:00",
+        "NOTIFICATION_EVENING_WINDOW": "21:00-22:00",
+        "NOTIFICATION_TIMEZONE": "UTC",
+    }
+
+    settings = config.load_settings(env)
+
+    assert settings.morning_window == "06:00-07:00"
+    assert settings.evening_window == "21:00-22:00"
+    assert settings.timezone == "UTC"
+
+
+def test_get_schedule_uses_cached_settings(monkeypatch):
+    monkeypatch.setenv("NOTIFICATION_MORNING_WINDOW", "07:00-08:00")
+    monkeypatch.setenv("NOTIFICATION_EVENING_WINDOW", "19:00-20:00")
+    monkeypatch.setenv("NOTIFICATION_TIMEZONE", "Europe/Paris")
+    config.get_settings.cache_clear()
+
+    schedule = config.get_schedule()
+
+    assert schedule.morning.start == time(7, 0)
+    assert schedule.evening.start == time(19, 0)
+    assert schedule.timezone == "Europe/Paris"

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,34 @@
+# Guía de despliegue
+
+Esta guía describe cómo publicar la aplicación en plataformas gratuitas tanto para el backend (FastAPI) como para el frontend estático.
+
+## Backend en Render
+
+1. Crea una cuenta gratuita en [Render](https://render.com/).
+2. Importa el repositorio desde GitHub y elige la rama que quieras desplegar.
+3. Configura el servicio con los siguientes valores:
+   - **Type**: Web Service.
+   - **Runtime**: Python.
+   - **Build Command**: `pip install -r requirements.txt`.
+   - **Start Command**: `uvicorn backend.app.main:app --host 0.0.0.0 --port 10000`.
+   - **Environment**: agrega las variables `NOTIFICATION_MORNING_WINDOW`, `NOTIFICATION_EVENING_WINDOW` y `NOTIFICATION_TIMEZONE` según tus necesidades. Si no las configuras se usarán los valores por defecto documentados en `backend/app/config.py`.
+4. Render detectará automáticamente el archivo `render.yaml` incluido en el repositorio, por lo que los valores anteriores quedarán registrados y los despliegues posteriores serán automáticos tras cada push a `main`.
+
+## Frontend en Netlify
+
+1. Accede a [Netlify](https://app.netlify.com/) y selecciona **Add new site → Import an existing project**.
+2. Autoriza a Netlify a leer este repositorio.
+3. Cuando se te solicite la configuración de build indica:
+   - **Build command**: *(vacío, no es necesario compilar)*.
+   - **Publish directory**: `Desarrollo web`.
+4. Netlify utilizará el archivo `netlify.toml` del repositorio para recordar estas opciones y crear un entorno de previsualización por cada pull request.
+
+## Actualizar variables de entorno
+
+En ambos servicios podrás definir las variables de entorno desde sus paneles de configuración. Tras modificar alguna ventana de notificación, solicita un redeploy manual para que la API lea los nuevos valores.
+
+## Checklist previo al despliegue
+
+- Ejecutar `ruff check .` y `pytest` en local.
+- Revisar que las rutas críticas de la web sigan cargando en el entorno de staging de Netlify.
+- Confirmar desde Render que el endpoint `GET /notifications/schedule` devuelve las ventanas esperadas.

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,7 @@
+[build]
+  publish = "Desarrollo web"
+  command = ""
+
+[dev]
+  port = 8080
+  publish = "Desarrollo web"

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: computing-backend
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: uvicorn backend.app.main:app --host 0.0.0.0 --port 10000
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.11.6

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,5 @@
+-r requirements.txt
+httpx==0.26.0
+pytest==8.1.1
+pytest-asyncio==0.23.5
+ruff==0.3.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi==0.110.0
+pydantic==2.6.4
+uvicorn[standard]==0.27.1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,4 @@
+line-length = 100
+extend-select = ["C4", "I"]
+[per-file-ignores]
+"backend/tests/*" = ["S101"]


### PR DESCRIPTION
## Summary
- add a FastAPI backend that exposes the notification schedule using validated time windows
- cover the scheduling logic with unit tests and the HTTP endpoints with end-to-end tests while wiring them into GitHub Actions CI
- document free hosting steps for Render and Netlify, adding the corresponding configuration files

## Testing
- ⚠️ `pip install -r requirements-dev.txt` *(fails: proxy returns 403 when downloading Python packages)*

------
https://chatgpt.com/codex/tasks/task_e_6905f4f788988324a7a48e79231297db